### PR TITLE
Adds resource requests and limits to all Deployments of the operator

### DIFF
--- a/manifest/olm-csv.yaml
+++ b/manifest/olm-csv.yaml
@@ -139,6 +139,13 @@ spec:
                   env:
                   - name: CRD
                     value: "true"
+                  resources:
+                    requests:
+                      memory: "64Mi"
+                      cpu: "250m"
+                    limits:
+                      memory: "128Mi"
+                      cpu: "500m"
               restartPolicy: Always
               terminationGracePeriodSeconds: 5
               serviceAccountName: spark-operator

--- a/manifest/olm-csv.yaml
+++ b/manifest/olm-csv.yaml
@@ -141,10 +141,10 @@ spec:
                     value: "true"
                   resources:
                     requests:
-                      memory: "64Mi"
+                      memory: "128Mi"
                       cpu: "250m"
                     limits:
-                      memory: "128Mi"
+                      memory: "256Mi"
                       cpu: "500m"
               restartPolicy: Always
               terminationGracePeriodSeconds: 5

--- a/manifest/operator-crd.yaml
+++ b/manifest/operator-crd.yaml
@@ -44,10 +44,10 @@ spec:
           value: "true"
         resources:
           requests:
-            memory: "64Mi"
+            memory: "128Mi"
             cpu: "250m"
           limits:
-            memory: "128Mi"
+            memory: "256Mi"
             cpu: "500m"
         imagePullPolicy: IfNotPresent
 

--- a/manifest/operator-crd.yaml
+++ b/manifest/operator-crd.yaml
@@ -42,5 +42,12 @@ spec:
         env:
         - name: CRD
           value: "true"
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "250m"
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
         imagePullPolicy: IfNotPresent
 

--- a/manifest/operator.yaml
+++ b/manifest/operator.yaml
@@ -52,5 +52,12 @@ spec:
         #  value: true
         #- name: COLORS
         #  value: false
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "250m"
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
         imagePullPolicy: IfNotPresent
 

--- a/manifest/operator.yaml
+++ b/manifest/operator.yaml
@@ -54,10 +54,10 @@ spec:
         #  value: false
         resources:
           requests:
-            memory: "64Mi"
+            memory: "128Mi"
             cpu: "250m"
           limits:
-            memory: "128Mi"
+            memory: "256Mi"
             cpu: "500m"
         imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION
Resource requests and limits are now set on all deployments of the operator that I could find in the repo.

## Description
See description above.

## Related Issue

#82 

## Types of changes

- [ ] Updated docs / Refactor code / Added a tests case / Automation (non-breaking change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
