### PR TITLE
Fixes conditional running of maven deploy so that it only runs on mas…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,4 @@ jobs:
         # or release the latest image if building the master branch
         - ./.travis/.travis.release.images.sh
         # release maven artifacts
-        - "[ $TRAVIS_PULL_REQUEST == false ] && make build-travis && ./mvnw -s ./.travis/settings.xml clean deploy"
+        - 'if [[ $TRAVIS_PULL_REQUEST == "false" ]] && [[ $TRAVIS_BRANCH == "master" ]] ; then make build-travis && ./mvnw -s ./.travis/settings.xml clean deploy; fi'


### PR DESCRIPTION
…ter builds that are not a pull request.

## Description
My PRs are currently failing due to the bash test `[ $TRAVIS_PULL_REQUEST == false ]` returning a non-zero return code, causing travis to mark the build as a failure.

This commit replaces the command chaining syntax with a proper if
statement so that the command still returns a successful code even when
the expression evaluates false.

I also added a check on `$TRAVIS_BRANCH` as I naïvely assume that
snapshots should probably not be published from random branches on the
main repo either (unless the version number has changed in the pom, but
I'm not writing that logic in a bash one-liner).

## Related Issue


## Types of changes

- [x] Updated docs / Refactor code / Added a tests case / Automation (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
