### PR TITLE
Upgrade jsonschema2pojo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
             <plugin>
                 <groupId>org.jsonschema2pojo</groupId>
                 <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+                <version>1.0.0-beta1</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
+++ b/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
@@ -4,9 +4,9 @@ import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.radanalytics.operator.resource.LabelsHelper;
 import io.radanalytics.types.DownloadDatum;
+import io.radanalytics.types.Env;
 import io.radanalytics.types.Master;
 import io.radanalytics.types.SparkCluster;
-import io.radanalytics.types.SparkConfiguration;
 
 import java.util.*;
 
@@ -168,7 +168,7 @@ public class KubernetesSparkClusterDeployer {
                                                     SparkCluster cluster,
                                                     boolean cmExists) {
         final List<DownloadDatum> downloadData = cluster.getDownloadData();
-        final List<SparkConfiguration> config = cluster.getSparkConfiguration();
+        final List<Env> config = cluster.getSparkConfiguration();
         final boolean needInitContainer = !downloadData.isEmpty() || !config.isEmpty();
         final StringBuilder command = new StringBuilder();
         if (needInitContainer) {

--- a/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
+++ b/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
@@ -4,8 +4,7 @@ import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.radanalytics.operator.resource.LabelsHelper;
 import io.radanalytics.types.DownloadDatum;
-import io.radanalytics.types.Env;
-import io.radanalytics.types.Master;
+import io.radanalytics.types.RCSpec;
 import io.radanalytics.types.SparkCluster;
 
 import java.util.*;
@@ -108,7 +107,7 @@ public class KubernetesSparkClusterDeployer {
 
         // limits
         if (isMaster) {
-            final Master master = Optional.ofNullable(cluster.getMaster()).orElse(new Master());
+            final RCSpec master = Optional.ofNullable(cluster.getMaster()).orElse(new RCSpec());
 
             Map<String, Quantity> limits = new HashMap<>(2);
             Optional.ofNullable(master.getMemory()).ifPresent(memory -> limits.put("memory", new Quantity(memory)));
@@ -118,7 +117,7 @@ public class KubernetesSparkClusterDeployer {
                 containerBuilder.withResources(new ResourceRequirements(limits, limits));
             }
         } else {
-            final Master worker = Optional.ofNullable(cluster.getWorker()).orElse(new Master());
+            final RCSpec worker = Optional.ofNullable(cluster.getWorker()).orElse(new RCSpec());
 
             Map<String, Quantity> limits = new HashMap<>(2);
             Optional.ofNullable(worker.getMemory()).ifPresent(memory -> limits.put("memory", new Quantity(memory)));
@@ -147,9 +146,9 @@ public class KubernetesSparkClusterDeployer {
                 .withNewSpec().withReplicas(
                         isMaster
                                 ?
-                                Optional.ofNullable(cluster.getMaster()).orElse(new Master()).getReplicas()
+                                Optional.ofNullable(cluster.getMaster()).orElse(new RCSpec()).getReplicas()
                                 :
-                                Optional.ofNullable(cluster.getWorker()).orElse(new Master()).getReplicas()
+                                Optional.ofNullable(cluster.getWorker()).orElse(new RCSpec()).getReplicas()
                 )
                 .withSelector(selector)
                 .withNewTemplate().withNewMetadata().withLabels(podLabels).endMetadata()
@@ -168,7 +167,7 @@ public class KubernetesSparkClusterDeployer {
                                                     SparkCluster cluster,
                                                     boolean cmExists) {
         final List<DownloadDatum> downloadData = cluster.getDownloadData();
-        final List<Env> config = cluster.getSparkConfiguration();
+        final List<io.radanalytics.types.EnvVar> config = cluster.getSparkConfiguration();
         final boolean needInitContainer = !downloadData.isEmpty() || !config.isEmpty();
         final StringBuilder command = new StringBuilder();
         if (needInitContainer) {

--- a/src/main/java/io/radanalytics/operator/cluster/SparkClusterOperator.java
+++ b/src/main/java/io/radanalytics/operator/cluster/SparkClusterOperator.java
@@ -3,7 +3,7 @@ package io.radanalytics.operator.cluster;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.radanalytics.operator.common.AbstractOperator;
 import io.radanalytics.operator.common.Operator;
-import io.radanalytics.types.Master;
+import io.radanalytics.types.RCSpec;
 import io.radanalytics.types.SparkCluster;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,8 +41,8 @@ public class SparkClusterOperator extends AbstractOperator<SparkCluster> {
     protected void onModify(SparkCluster newCluster) {
         String name = newCluster.getName();
         String newImage = newCluster.getCustomImage();
-        int newMasters = Optional.ofNullable(newCluster.getMaster()).orElse(new Master()).getReplicas();
-        int newWorkers = Optional.ofNullable(newCluster.getWorker()).orElse(new Master()).getReplicas();
+        int newMasters = Optional.ofNullable(newCluster.getMaster()).orElse(new RCSpec()).getReplicas();
+        int newWorkers = Optional.ofNullable(newCluster.getWorker()).orElse(new RCSpec()).getReplicas();
         SparkCluster existingCluster = clusters.getCluster(name);
         if (null == existingCluster) {
             log.error("something went wrong, unable to scale existing cluster. Perhaps it wasn't deployed properly.");

--- a/src/main/resources/schema/sparkCluster.json
+++ b/src/main/resources/schema/sparkCluster.json
@@ -21,12 +21,9 @@
       "type": "string"
     },
     "env": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/EnvVar"
-      }
+      "$ref": "#/definitions/Environment"
     },
-    "sparkConfiguration": { "$ref": "#/properties/env" },
+    "sparkConfiguration": { "$ref": "#/definitions/Environment" },
     "downloadData": {
       "type": "array",
       "items": {
@@ -64,6 +61,12 @@
         "value": { "type": "string" }
       },
       "required": ["name", "value"]
+    },
+    "Environment": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/EnvVar"
+      }
     }
   }
 }

--- a/src/main/resources/schema/sparkCluster.json
+++ b/src/main/resources/schema/sparkCluster.json
@@ -23,12 +23,7 @@
     "env": {
       "type": "array",
       "items": {
-        "type": "object",
-        "properties": {
-          "name": { "type": "string" },
-          "value": { "type": "string" }
-        },
-        "required": ["name", "value"]
+        "$ref": "#/definitions/EnvVar"
       }
     },
     "sparkConfiguration": { "$ref": "#/properties/env" },
@@ -61,6 +56,14 @@
           "type": "string"
         }
       }
+    },
+    "EnvVar": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "value": { "type": "string" }
+      },
+      "required": ["name", "value"]
     }
   }
 }


### PR DESCRIPTION
## Description

In order to fix an issue with some strange type assignments (e.g. `getWorker()` returned a `Master` instance) I have upgraded the jsonschema2pojo plugin, made some small adjustments to the schema to ensure correct reuse/name of env/sparkConfiguration and updated the code to ensure it still compiles and passes unit tests. 

## Related Issue

No issue, this was a follow up from https://github.com/radanalyticsio/spark-operator/pull/103 to resolve the issue with the types generated by jsonschema2pojo

## Types of changes

- [x] Updated docs / Refactor code / Added a tests case / Automation (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
