### PR TITLE
custom labels for kube resources

### DIFF
--- a/examples/cluster-cr-with-labels.yaml
+++ b/examples/cluster-cr-with-labels.yaml
@@ -1,0 +1,18 @@
+apiVersion: radanalytics.io/v1
+kind: sparkcluster
+metadata:
+  name: spark-cluster-with-labels
+spec:
+  worker:
+    replicas: "2"
+    labels:
+      example-label-for-all-workers/bar: foo
+      common-label-to-be-replaced-on-some-resources: worker-value
+  master:
+    replicas: "1"
+    labels:
+      example-label-for-master/foo: bar
+      common-label-to-be-replaced-on-some-resources: master-value
+  labels:
+    common-label-for-all-the-resources-operator-deploys/deployed-by: john
+    common-label-to-be-replaced-on-some-resources: global-value

--- a/examples/cluster-with-labels.yaml
+++ b/examples/cluster-with-labels.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spark-cluster-with-labels
+  labels:
+    radanalytics.io/kind: sparkcluster
+data:
+  config: |-
+    worker:
+      replicas: "2"
+      labels:
+        example-label-for-all-workers/bar: foo
+        common-label-to-be-replaced-on-some-resources: worker-value
+    master:
+      replicas: "1"
+      labels:
+        example-label-for-master/foo: bar
+        common-label-to-be-replaced-on-some-resources: master-value
+    labels:
+      common-label-for-all-the-resources-operator-deploys/deployed-by: john
+      common-label-to-be-replaced-on-some-resources: global-value

--- a/src/main/resources/schema/sparkCluster.json
+++ b/src/main/resources/schema/sparkCluster.json
@@ -24,6 +24,10 @@
       "$ref": "#/definitions/Environment"
     },
     "sparkConfiguration": { "$ref": "#/definitions/Environment" },
+    "labels" : {
+      "existingJavaType" : "java.util.Map<String,String>",
+      "type" : "object"
+    },
     "downloadData": {
       "type": "array",
       "items": {
@@ -51,6 +55,10 @@
         },
         "cpu": {
           "type": "string"
+        },
+        "labels" : {
+          "existingJavaType" : "java.util.Map<String,String>",
+          "type" : "object"
         }
       }
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->


## Description
Adding possibility to specify custom labels for kube resources. 
The labels in the spec.labels should be applied on all the resources we create in the K8s cluster, I.e. pods, services, RCs.
Those labels under spec.{woker|master}.labels should be applied only on the pods for worker or master.


## Related Issue
Fixes #53


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in one box that applies: -->

- [ ] Updated docs / Refactor code / Added a tests case / Automation (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
