### PR TITLE
Fix #131 - recreate the cluster for other changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <abstract-operator.version>0.4.1</abstract-operator.version>
+        <abstract-operator.version>0.4.2</abstract-operator.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <abstract-operator.version>0.4.2</abstract-operator.version>
+        <abstract-operator.version>0.4.3</abstract-operator.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
scaling the workers are handled in special manner, because the fabric8 client can't do similar thing as `kubectl apply`... the `createOrReplace` method will always destroy and create new, that is overkill in case of _ONLY_ scaling

Fix #131 
