### PR TITLE
Optional sleep for spark apps

### DIFF
--- a/examples/app.yaml
+++ b/examples/app.yaml
@@ -9,6 +9,7 @@ data:
     image: quay.io/jkremser/openshift-spark:2.3-latest
     mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.11-2.3.0.jar
     mainClass: org.apache.spark.examples.SparkPi
+    sleep: 300 # repeat each 5 minutes
     labels:
       foo: bar
       foo2: bar2

--- a/src/main/java/io/radanalytics/operator/app/KubernetesAppDeployer.java
+++ b/src/main/java/io/radanalytics/operator/app/KubernetesAppDeployer.java
@@ -22,29 +22,25 @@ public class KubernetesAppDeployer {
     }
 
     public KubernetesResourceList getResourceList(SparkApplication app, String namespace) {
-        String name = app.getName();
-        String image = app.getImage();
-        String file = app.getMainApplicationFile();
-        String main = app.getMainClass();
-
-        ReplicationController submitter = getSubmitterRc(name, image, file, main, namespace);
+        ReplicationController submitter = getSubmitterRc(app, namespace);
         KubernetesList resources = new KubernetesListBuilder().withItems(submitter).build();
         return resources;
     }
 
-    private ReplicationController getSubmitterRc(String name, String image, String file, String main,
-                                                        String namespace) {
+    private ReplicationController getSubmitterRc(SparkApplication app, String namespace) {
         List<EnvVar> envVars = new ArrayList<>();
         envVars.add(env("FOO", "bar"));
 
+        final String name = app.getName();
+
         StringBuilder command = new StringBuilder();
         command.append("/opt/spark/bin/spark-submit");
-        command.append(" --class ").append(main);
+        command.append(" --class ").append(app.getMainApplicationFile());
         command.append(" --master k8s://https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT");
         command.append(" --conf spark.kubernetes.namespace=").append(namespace);
         command.append(" --deploy-mode cluster");
         command.append(" --conf spark.app.name=").append(name);
-        command.append(" --conf spark.kubernetes.container.image=").append(image);
+        command.append(" --conf spark.kubernetes.container.image=").append(app.getImage());
         command.append(" --conf spark.kubernetes.submission.waitAppCompletion=false");
         command.append(" --conf spark.kubernetes.driver.label.radanalytics.io/sparkapplication=").append(name);
         command.append(" --conf spark.driver.cores=0.100000");
@@ -58,12 +54,14 @@ public class KubernetesAppDeployer {
         command.append(" --conf spark.executor.memory=512m");
         command.append(" --conf spark.kubernetes.executor.label.version=2.3.0");
         command.append(" --conf spark.jars.ivy=/tmp/.ivy2");
-        command.append(" ").append(file);
-        command.append(" && sleep 31536000");
+        command.append(" ").append(app.getMainApplicationFile());
+        if (app.getSleep() > 0) {
+            command.append(" && sleep ").append(app.getSleep());
+        }
 
         ContainerBuilder containerBuilder = new ContainerBuilder()
                 .withEnv(envVars)
-                .withImage(image)
+                .withImage(app.getImage())
                 .withImagePullPolicy("IfNotPresent")
                 .withName(name)
                 .withTerminationMessagePath("/dev/termination-log")

--- a/src/main/java/io/radanalytics/operator/app/KubernetesAppDeployer.java
+++ b/src/main/java/io/radanalytics/operator/app/KubernetesAppDeployer.java
@@ -56,6 +56,7 @@ public class KubernetesAppDeployer {
         command.append(" --conf spark.jars.ivy=/tmp/.ivy2");
         command.append(" ").append(app.getMainApplicationFile());
         if (app.getSleep() > 0) {
+            command.append(" && echo -e '\\n\\ntask/pod will be rescheduled in ").append(app.getSleep()).append(" seconds..'");
             command.append(" && sleep ").append(app.getSleep());
         }
 

--- a/src/main/resources/schema/sparkApplication.json
+++ b/src/main/resources/schema/sparkApplication.json
@@ -18,7 +18,7 @@
     },
     "image": {
       "type": "string",
-      "default": "quay.io/jkremser/openshift-spark-app:2.3-latest"
+      "default": "quay.io/jkremser/openshift-spark:2.3-latest"
     },
     "mainApplicationFile": {
       "type": "string"
@@ -42,6 +42,11 @@
     "type": {
       "type": "string",
       "enum": ["Java", "Scala", "Python", "R"]
+    },
+    "sleep": {
+      "type": "integer",
+      "default": 300,
+      "minimum": 0
     },
     "labels": {
       "$ref": "#/definitions/Labels"

--- a/src/main/resources/schema/sparkApplication.json
+++ b/src/main/resources/schema/sparkApplication.json
@@ -45,7 +45,7 @@
     },
     "sleep": {
       "type": "integer",
-      "default": 300,
+      "default": 31536000,
       "minimum": 0
     },
     "labels": {


### PR DESCRIPTION
Make the sleep after spark-submit optional and configurable for the spark apps operator. If not specified the default is 1 year.

Nice side-effect of this change is the fact that once the sleep is done, the container finishes its work and the pod is killed and created again by the replication controller => repeated task.

In other words the `spark-submit` with the K8s as the native scheduler will be called in the `sleep n` intervals.