### PR TITLE
Fix #149: operator should deploy resources to the same namespace it is watching

### DIFF
--- a/src/main/java/io/radanalytics/operator/app/AppOperator.java
+++ b/src/main/java/io/radanalytics/operator/app/AppOperator.java
@@ -21,14 +21,14 @@ public class AppOperator extends AbstractOperator<SparkApplication> {
     @Override
     protected void onAdd(SparkApplication app) {
         KubernetesResourceList list = deployer.getResourceList(app, namespace);
-        client.resourceList(list).createOrReplace();
+        client.resourceList(list).inNamespace(namespace).createOrReplace();
     }
 
     @Override
     protected void onDelete(SparkApplication app) {
         String name = app.getName();
-        client.services().withLabels(deployer.getLabelsForDeletion(name)).delete();
-        client.replicationControllers().withLabels(deployer.getLabelsForDeletion(name)).delete();
-        client.pods().withLabels(deployer.getLabelsForDeletion(name)).delete();
+        client.services().inNamespace(namespace).withLabels(deployer.getLabelsForDeletion(name)).delete();
+        client.replicationControllers().inNamespace(namespace).withLabels(deployer.getLabelsForDeletion(name)).delete();
+        client.pods().inNamespace(namespace).withLabels(deployer.getLabelsForDeletion(name)).delete();
     }
 }

--- a/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
+++ b/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
@@ -16,11 +16,13 @@ public class KubernetesSparkClusterDeployer {
     private KubernetesClient client;
     private String entityName;
     private String prefix;
+    private String namespace;
 
-    KubernetesSparkClusterDeployer(KubernetesClient client, String entityName, String prefix) {
+    KubernetesSparkClusterDeployer(KubernetesClient client, String entityName, String prefix, String namespace) {
         this.client = client;
         this.entityName = entityName;
         this.prefix = prefix;
+        this.namespace = namespace;
     }
 
     public KubernetesResourceList getResourceList(SparkCluster cluster) {
@@ -269,7 +271,7 @@ public class KubernetesSparkClusterDeployer {
     }
 
     private boolean cmExists(String name) {
-        ConfigMap configMap = client.configMaps().withName(name).get();
+        ConfigMap configMap = client.configMaps().inNamespace(namespace).withName(name).get();
         return configMap != null && configMap.getData() != null && !configMap.getData().isEmpty();
     }
 


### PR DESCRIPTION
Fixes issue #149 

For this use-case (cross-namespace functionality) the default manifests need to be slightly altered. To my knowledge it's not doable without `ClusterRole` and `ClusterRoleBinding` so this cross-namespace deployment requires cluster admin to create those resources in the first place.