### PR TITLE
Metrics fu

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.radanalytics</groupId>
         <artifactId>operator-parent-pom</artifactId>
-        <version>0.3.10</version>
+        <version>0.3.11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.radanalytics</groupId>
@@ -19,7 +19,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <abstract-operator.version>0.4.14</abstract-operator.version>
+        <abstract-operator.version>0.4.15</abstract-operator.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/io/radanalytics/operator/cluster/MetricsHelper.java
+++ b/src/main/java/io/radanalytics/operator/cluster/MetricsHelper.java
@@ -1,0 +1,32 @@
+package io.radanalytics.operator.cluster;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+
+public class MetricsHelper {
+    private static final String PREFIX = "operator_";
+
+        public static final Counter reconciliationsTotal = Counter.build()
+                .name(PREFIX + "full_reconciliations_total")
+                .help("How many times the full reconciliation has been run.")
+                .labelNames("ns")
+                .register();
+
+        public static final Gauge runningClusters = Gauge.build()
+                .name(PREFIX + "running_clusters")
+                .help("Spark clusters that are currently running.")
+                .labelNames("ns")
+                .register();
+
+        public static final Gauge workers = Gauge.build()
+                .name(PREFIX + "running_workers")
+                .help("Number of workers per cluster name.")
+                .labelNames("cluster", "ns")
+                .register();
+
+        public static final Gauge startedTotal = Gauge.build()
+                .name(PREFIX + "started_clusters_total")
+                .help("Spark clusters has been started by operator.")
+                .labelNames("ns")
+                .register();
+}

--- a/src/main/java/io/radanalytics/operator/cluster/RunningClusters.java
+++ b/src/main/java/io/radanalytics/operator/cluster/RunningClusters.java
@@ -1,51 +1,42 @@
 package io.radanalytics.operator.cluster;
 
-import io.prometheus.client.Counter;
-import io.prometheus.client.Gauge;
+import io.prometheus.client.log4j.InstrumentedAppender;
 import io.radanalytics.types.RCSpec;
 import io.radanalytics.types.SparkCluster;
+import org.apache.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.radanalytics.operator.cluster.MetricsHelper.runningClusters;
+import static io.radanalytics.operator.cluster.MetricsHelper.startedTotal;
+import static io.radanalytics.operator.cluster.MetricsHelper.workers;
+
+
 
 public class RunningClusters {
 
-    public static final Gauge runningClusters = Gauge.build()
-            .name("operator_running_clusters")
-            .help("Spark clusters that are currently running.")
-            .register();
-
-    public static final Gauge workers = Gauge.build()
-            .name("operator_running_workers")
-            .help("Number of workers per cluster name.")
-            .labelNames("cluster")
-            .register();
-
-    public static final Gauge startedTotal = Gauge.build()
-            .name("operator_started_total")
-            .help("Spark clusters has been started by operator.")
-            .register();
-
     private final Map<String, SparkCluster> clusters;
+    private final String namespace;
 
-    public RunningClusters() {
+    public RunningClusters(String namespace) {
         clusters = new HashMap<>();
-        runningClusters.set(0);
+        this.namespace = namespace;
+        runningClusters.labels(namespace).set(0);
     }
 
     public void put(SparkCluster ci) {
-        runningClusters.inc();
-        startedTotal.inc();
-        workers.labels(ci.getName()).set(Optional.ofNullable(ci.getWorker()).orElse(new RCSpec()).getInstances());
+        runningClusters.labels(namespace).inc();
+        startedTotal.labels(namespace).inc();
+        workers.labels(ci.getName(), namespace).set(Optional.ofNullable(ci.getWorker()).orElse(new RCSpec()).getInstances());
         clusters.put(ci.getName(), ci);
     }
 
     public void delete(String name) {
         if (clusters.containsKey(name)) {
-            runningClusters.dec();
-            workers.labels(name).set(0);
+            runningClusters.labels(namespace).dec();
+            workers.labels(name, namespace).set(0);
             clusters.remove(name);
         }
     }
@@ -55,9 +46,9 @@ public class RunningClusters {
     }
 
     public void resetMetrics() {
-        startedTotal.set(0);
-        workers.clear();
-        startedTotal.set(0);
+        startedTotal.labels(namespace).set(0);
+        clusters.forEach((c, foo) -> workers.labels(c, namespace).set(0));
+        startedTotal.labels(namespace).set(0);
     }
 
 }


### PR DESCRIPTION
Improvement to the metrics:

- all the metrics can be now labeled by the namespace
- metric renamed: `operator_started_total` -> `operator_started_clusters_total`
- new metric for the number (counter) that tracks how many times the full reconciliation procedure has been run
- moving the concern that deals with metrics to it's own helper class


Also increasing the version of the abstract library and parent pom, this way the abstract library starts reporting also another useful information about the operator itself.. check https://github.com/jvm-operators/abstract-operator/commit/0273c20b427283f17cd697519b8c96ccaadf5739 for more details