### PR TITLE
Add sparkoperator Package for OLM and Operator Hub

### DIFF
--- a/manifest/olm/crd/radanalytics-spark.package.yaml
+++ b/manifest/olm/crd/radanalytics-spark.package.yaml
@@ -1,0 +1,4 @@
+packageName: radanalytics-spark
+channels:
+- name: alpha
+  currentCSV: sparkoperator.v0.3.3


### PR DESCRIPTION
- Adds radanalytics.package.yaml to OLM manifests to be used by
[Operator Lifecycle Manager (OLM)](https://github.com/operator-framework/operator-lifecycle-manager) to install, manage, and
upgrade the radanalytics sparkoperator in a cluster.
- The radanalytics sparkoperator versions available to all
Kubernetes clusters using OLM can be updated by submitting a pull
request to the [Community Operators GitHub repo](https://github.com/operator-framework/community-operators) that includes
the latest CSVs, CRDs, and Packages.
- For the sparkoperator, these are tracked in the community-operators repo [in this PR](https://github.com/operator-framework/community-operators/pull/45).

@Jiri-Kremser The package.yaml file is required for operators available through Operator Hub.