### PR TITLE
Update sparkoperator CSV for OLM

### DIFF
--- a/manifest/olm/crd/sparkclusteroperator.0.3.3.clusterserviceversion.yaml
+++ b/manifest/olm/crd/sparkclusteroperator.0.3.3.clusterserviceversion.yaml
@@ -55,6 +55,12 @@ spec:
         - apiGroups: [""]
           resources: ["pods", "replicationcontrollers", "services", "configmaps"]
           verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch", "patch"]
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - list
       deployments:
       - name: spark-operator
         namespace: openshift-operators
@@ -77,8 +83,10 @@ spec:
                   env:
                   - name: CRD
                     value: "true"
-                  - name: WATCHED_NAMESPACE
-                    value: "openshift_operators"
+                  - name: WATCH_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.annotations['olm.targetNamespaces']
                   resources:
                     limits:
                       memory: "750Mi"


### PR DESCRIPTION
- Adds clusterPermissions to list CRDs via apiextensions.k8s.io
- Sets `WATCH_NAMESPACE` to an annotation set by OLM

I've tested this on an OKD 4.0 cluster via the installer v0.11.0

@Jiri-Kremser The operator responds to CRs created in the operator namespace, but does not respond when CRs are created in other namespaces.