### PR TITLE
missing git sha

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,10 @@
                 <artifactId>maven-jar-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.jsonschema2pojo</groupId>
                 <artifactId>jsonschema2pojo-maven-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
Run the `buildnumber-maven-plugin` that actually populates the `buildNumber` variable that is then filled by the maven-jar-plugin into the manifest. Check the https://git.io/fh9nF for more defails.