### PR TITLE
update spark entity names

### DIFF
--- a/.travis/.travis.test-common.sh
+++ b/.travis/.travis.test-common.sh
@@ -98,7 +98,7 @@ testCreateOperator() {
   os::cmd::expect_success_and_text "${BIN} create -f $DIR/../manifest/operator$FOO$MANIFEST_SUFIX.yaml" '"?spark-operator"? created' && \
   os::cmd::try_until_text "${BIN} get pod -l app.kubernetes.io/name=spark-operator -o yaml" 'ready: true'
   if [ "$CRD" = "1" ]; then
-    os::cmd::try_until_text "${BIN} get crd" 'SparkClusters.radanalytics.io'
+    os::cmd::try_until_text "${BIN} get crd" 'sparkclusters.radanalytics.io'
   fi
   sleep 10
 }
@@ -114,7 +114,7 @@ testCreateCluster1() {
 testScaleCluster() {
   info
   if [ "$CRD" = "1" ]; then
-    os::cmd::expect_success_and_text '${BIN} patch SparkCluster my-spark-cluster -p "{\"spec\":{\"worker\": {\"instances\": 1}}}" --type=merge' '"?my-spark-cluster"? patched' || errorLogs
+    os::cmd::expect_success_and_text '${BIN} patch sparkcluster my-spark-cluster -p "{\"spec\":{\"worker\": {\"instances\": 1}}}" --type=merge' '"?my-spark-cluster"? patched' || errorLogs
   else
     os::cmd::expect_success_and_text '${BIN} patch cm my-spark-cluster -p "{\"data\":{\"config\": \"worker:\n  instances: 1\"}}"' '"?my-spark-cluster"? patched' || errorLogs
   fi

--- a/.travis/.travis.test-common.sh
+++ b/.travis/.travis.test-common.sh
@@ -5,7 +5,7 @@ BIN=${BIN:-oc}
 MANIFEST_SUFIX=${MANIFEST_SUFIX:-""}
 if [ "$CRD" = "1" ]; then
   CR="cr/"
-  KIND="sparkcluster"
+  KIND="SparkCluster"
 else
   CR=""
   KIND="cm"
@@ -76,7 +76,7 @@ errorLogs() {
 appErrorLogs() {
   checkNs
   echo -e "\n$(tput setaf 3)Spark Application Logs:$(tput sgr0)\n"
-  export submitter_pod=`${BIN} get pod -l radanalytics.io/kind=sparkapplication -o='jsonpath="{.items[0].metadata.name}"' | sed 's/"//g'`
+  export submitter_pod=`${BIN} get pod -l radanalytics.io/kind=SparkApplication -o='jsonpath="{.items[0].metadata.name}"' | sed 's/"//g'`
   ${BIN} get all
   ${BIN} logs $submitter_pod
   errorLogs
@@ -98,7 +98,7 @@ testCreateOperator() {
   os::cmd::expect_success_and_text "${BIN} create -f $DIR/../manifest/operator$FOO$MANIFEST_SUFIX.yaml" '"?spark-operator"? created' && \
   os::cmd::try_until_text "${BIN} get pod -l app.kubernetes.io/name=spark-operator -o yaml" 'ready: true'
   if [ "$CRD" = "1" ]; then
-    os::cmd::try_until_text "${BIN} get crd" 'sparkclusters.radanalytics.io'
+    os::cmd::try_until_text "${BIN} get crd" 'SparkClusters.radanalytics.io'
   fi
   sleep 10
 }
@@ -114,17 +114,17 @@ testCreateCluster1() {
 testScaleCluster() {
   info
   if [ "$CRD" = "1" ]; then
-    os::cmd::expect_success_and_text '${BIN} patch sparkcluster my-spark-cluster -p "{\"spec\":{\"worker\": {\"instances\": 1}}}" --type=merge' '"?my-spark-cluster"? patched' || errorLogs
+    os::cmd::expect_success_and_text '${BIN} patch SparkCluster my-spark-cluster -p "{\"spec\":{\"worker\": {\"instances\": 1}}}" --type=merge' '"?my-spark-cluster"? patched' || errorLogs
   else
     os::cmd::expect_success_and_text '${BIN} patch cm my-spark-cluster -p "{\"data\":{\"config\": \"worker:\n  instances: 1\"}}"' '"?my-spark-cluster"? patched' || errorLogs
   fi
-  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/sparkcluster=my-spark-cluster | wc -l" '2'
+  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/SparkCluster=my-spark-cluster | wc -l" '2'
 }
 
 testDeleteCluster() {
   info
   os::cmd::expect_success_and_text '${BIN} delete ${KIND} my-spark-cluster' '"?my-spark-cluster"? deleted' && \
-  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/sparkcluster=my-spark-cluster 2> /dev/null | wc -l" '0'
+  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/SparkCluster=my-spark-cluster 2> /dev/null | wc -l" '0'
 }
 
 testCreateCluster2() {
@@ -154,7 +154,7 @@ testFullConfigCluster() {
   os::cmd::expect_success_and_text "${BIN} create -f $DIR/../examples/cluster-with-config.yaml" '"?sparky-cluster"? created' && \
   os::cmd::try_until_text "${BIN} get pod -l radanalytics.io/deployment=sparky-cluster-w -o yaml" 'ready: true' && \
   os::cmd::try_until_text "${BIN} get pod -l radanalytics.io/deployment=sparky-cluster-m -o yaml" 'ready: true' && \
-  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/sparkcluster=sparky-cluster | wc -l" '3' && \
+  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/SparkCluster=sparky-cluster | wc -l" '3' && \
   sleep 10 && \
   local worker_pod=`${BIN} get pod -l radanalytics.io/deployment=sparky-cluster-w -o='jsonpath="{.items[0].metadata.name}"' | sed 's/"//g'` && \
   os::cmd::expect_success_and_text "${BIN} exec $worker_pod ls" 'README.md' && \
@@ -182,17 +182,17 @@ testCustomCluster2() {
   refreshOperatorPod
   os::cmd::expect_success_and_text "${BIN} create -f $DIR/../examples/test/${CR}cluster-2.yaml" '"?my-spark-cluster-2"? created' && \
   #os::cmd::try_until_text "${BIN} logs $operator_pod | grep my-spark-cluster-2" "creat\(ed\|ing\)" && \   (colors)
-  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/sparkcluster=my-spark-cluster-2 | wc -l" '3' && \
+  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/SparkCluster=my-spark-cluster-2 | wc -l" '3' && \
   os::cmd::expect_success_and_text '${BIN} delete ${KIND} my-spark-cluster-2' '"my-spark-cluster-2" deleted' && \
   #os::cmd::try_until_text "${BIN} logs $operator_pod | grep my-spark-cluster-2" "deleted" && \   (colors)
-  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/sparkcluster=my-spark-cluster-2 | wc -l" '0'
+  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/SparkCluster=my-spark-cluster-2 | wc -l" '0'
 }
 
 testCustomCluster3() {
   info
   sleep 2
   os::cmd::expect_success_and_text "${BIN} create -f $DIR/../examples/test/${CR}cluster-with-config-1.yaml" '"?sparky-cluster-1"? created' && \
-  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/sparkcluster=sparky-cluster-1 | wc -l" '2' && \
+  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/SparkCluster=sparky-cluster-1 | wc -l" '2' && \
   local worker_pod=`${BIN} get pod -l radanalytics.io/deployment=sparky-cluster-1-w -o='jsonpath="{.items[0].metadata.name}"' | sed 's/"//g'` && \
   os::cmd::try_until_text "${BIN} exec $worker_pod cat /opt/spark/conf/spark-defaults.conf" 'spark.executor.memory 1g' && \
   os::cmd::expect_success_and_text "${BIN} exec $worker_pod ls" 'README.md' && \
@@ -203,7 +203,7 @@ testCustomCluster4() {
   info
   sleep 2
   os::cmd::expect_success_and_text "${BIN} create -f $DIR/../examples/test/${CR}cluster-with-config-2.yaml" '"?sparky-cluster-2"? created' && \
-  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/sparkcluster=sparky-cluster-2 | wc -l" '2' && \
+  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/SparkCluster=sparky-cluster-2 | wc -l" '2' && \
   local worker_pod=`${BIN} get pod -l radanalytics.io/deployment=sparky-cluster-2-w -o='jsonpath="{.items[0].metadata.name}"' | sed 's/"//g'` && \
   os::cmd::try_until_text "${BIN} exec $worker_pod cat /opt/spark/conf/spark-defaults.conf" 'spark.executor.memory 3g' && \
   os::cmd::expect_success_and_text '${BIN} delete ${KIND} sparky-cluster-2' '"sparky-cluster-2" deleted'
@@ -215,10 +215,10 @@ testCustomCluster5() {
   sleep 2
   refreshOperatorPod
   os::cmd::expect_success_and_text "${BIN} create -f $DIR/../examples/test/${CR}cluster-with-config-3.yaml" '"?sparky-cluster-3"? created' && \
-  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/sparkcluster=sparky-cluster-3 | wc -l" '2' && \
+  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/SparkCluster=sparky-cluster-3 | wc -l" '2' && \
   #os::cmd::try_until_text "${BIN} logs $operator_pod | grep sparky-cluster-3" "created" && \
   os::cmd::expect_success_and_text '${BIN} delete ${KIND} sparky-cluster-3' '"sparky-cluster-3" deleted' && \
-  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/sparkcluster=my-spark-cluster-3 | wc -l" '0'
+  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/SparkCluster=my-spark-cluster-3 | wc -l" '0'
 }
 
 testApp() {
@@ -226,21 +226,21 @@ testApp() {
   [ "$CRD" = "1" ] && FOO="test/cr/" || FOO=""
   os::cmd::expect_success_and_text '${BIN} create -f examples/${FOO}app.yaml' '"?my-spark-app"? created' && \
   # 1 submitter, 1 driver and 2 executors
-  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/sparkapplication=my-spark-app 2> /dev/null | wc -l" '4'
+  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/SparkApplication=my-spark-app 2> /dev/null | wc -l" '4'
 }
 
 testAppResult() {
   info
   sleep 2
-  local driver_pod=`${BIN} get pods --no-headers -l radanalytics.io/sparkapplication=my-spark-app -l spark-role=driver -o='jsonpath="{.items[0].metadata.name}"' | sed 's/"//g'` && \
+  local driver_pod=`${BIN} get pods --no-headers -l radanalytics.io/SparkApplication=my-spark-app -l spark-role=driver -o='jsonpath="{.items[0].metadata.name}"' | sed 's/"//g'` && \
   os::cmd::try_until_text "${BIN} logs $driver_pod" 'Pi is roughly 3.1'
 }
 
 testDeleteApp() {
   info
-  [ "$CRD" = "1" ] && FOO="sparkapplication" || FOO="cm"
+  [ "$CRD" = "1" ] && FOO="SparkApplication" || FOO="cm"
   os::cmd::expect_success_and_text '${BIN} delete ${FOO} my-spark-app' '"my-spark-app" deleted' && \
-  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/sparkapplication=my-spark-app 2> /dev/null | wc -l" '0'
+  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/SparkApplication=my-spark-app 2> /dev/null | wc -l" '0'
 }
 
 testPythonApp() {
@@ -248,14 +248,14 @@ testPythonApp() {
   [ "$CRD" = "1" ] && return 0
   os::cmd::expect_success_and_text '${BIN} create -f examples/apps/pyspark-ntlk.yaml' '"?ntlk-example"? created' && \
   # number of pods w/ spark app = 3 (1 executor, 1 driver, 1 submitter)
-  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/sparkapplication=ntlk-example 2> /dev/null | wc -l" '3'
+  os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/SparkApplication=ntlk-example 2> /dev/null | wc -l" '3'
 }
 
 testPythonAppResult() {
   info
   [ "$CRD" = "1" ] && return 0
   sleep 2
-  local driver_pod=`${BIN} get pods --no-headers -l radanalytics.io/sparkapplication=ntlk-example -l spark-role=driver -o='jsonpath="{.items[0].metadata.name}"' | sed 's/"//g'` && \
+  local driver_pod=`${BIN} get pods --no-headers -l radanalytics.io/SparkApplication=ntlk-example -l spark-role=driver -o='jsonpath="{.items[0].metadata.name}"' | sed 's/"//g'` && \
   os::cmd::try_until_text "${BIN} logs $driver_pod" 'Lorem'
 }
 

--- a/.travis/.travis.test-cross-ns.sh
+++ b/.travis/.travis.test-cross-ns.sh
@@ -5,7 +5,7 @@ BIN=${BIN:-oc}
 MANIFEST_SUFIX=${MANIFEST_SUFIX:-""}
 if [ "$CRD" = "1" ]; then
   CR="cr/"
-  KIND="sparkcluster"
+  KIND="SparkCluster"
 else
   CR=""
   KIND="cm"

--- a/.travis/.travis.test-oc-and-k8s.sh
+++ b/.travis/.travis.test-oc-and-k8s.sh
@@ -5,7 +5,7 @@ BIN=${BIN:-oc}
 MANIFEST_SUFIX=${MANIFEST_SUFIX:-""}
 if [ "$CRD" = "1" ]; then
   CR="cr/"
-  KIND="sparkcluster"
+  KIND="SparkCluster"
 else
   CR=""
   KIND="cm"

--- a/.travis/.travis.test-restarts.sh
+++ b/.travis/.travis.test-restarts.sh
@@ -5,7 +5,7 @@ BIN=${BIN:-oc}
 MANIFEST_SUFIX=${MANIFEST_SUFIX:-""}
 if [ "$CRD" = "1" ]; then
   CR="cr/"
-  KIND="sparkcluster"
+  KIND="SparkCluster"
 else
   CR=""
   KIND="cm"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ kind: ConfigMap
 metadata:
   name: my-cluster
   labels:
-    radanalytics.io/kind: sparkcluster
+    radanalytics.io/kind: SparkCluster
 data:
   config: |-
     worker:
@@ -82,7 +82,7 @@ and then create the Spark clusters by creating the custom resources (CR).
 
 ```bash
 kubectl apply -f examples/cluster-cr.yaml
-kubectl get sparkclusters
+kubectl get SparkClusters
 ```
 
 ### Images

--- a/examples/app.yaml
+++ b/examples/app.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: my-spark-app
   labels:
-    radanalytics.io/kind: sparkapplication
+    radanalytics.io/kind: SparkApplication
 data:
   config: |-
     image: quay.io/jkremser/openshift-spark:2.3-latest

--- a/examples/apps/pyspark-ntlk.yaml
+++ b/examples/apps/pyspark-ntlk.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: ntlk-example
   labels:
-    radanalytics.io/kind: sparkapplication
+    radanalytics.io/kind: SparkApplication
 data:
   config: |-
     image: jkremser/spark-operator:2.4.0-ntlk

--- a/examples/cluster-cr-with-labels.yaml
+++ b/examples/cluster-cr-with-labels.yaml
@@ -1,5 +1,5 @@
 apiVersion: radanalytics.io/v1
-kind: sparkcluster
+kind: SparkCluster
 metadata:
   name: spark-cluster-with-labels
 spec:

--- a/examples/cluster-cr.yaml
+++ b/examples/cluster-cr.yaml
@@ -1,5 +1,5 @@
 apiVersion: radanalytics.io/v1
-kind: sparkcluster
+kind: SparkCluster
 metadata:
   name: my-spark-cluster
 spec:

--- a/examples/cluster-with-config.yaml
+++ b/examples/cluster-with-config.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: sparky-cluster                                  # compulsory
   labels:
-    radanalytics.io/kind: sparkcluster                       # compulsory
+    radanalytics.io/kind: SparkCluster                       # compulsory
 data:
   config: |-
     worker:

--- a/examples/cluster-with-labels.yaml
+++ b/examples/cluster-with-labels.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: spark-cluster-with-labels
   labels:
-    radanalytics.io/kind: sparkcluster
+    radanalytics.io/kind: SparkCluster
 data:
   config: |-
     worker:

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: my-spark-cluster
   labels:
-    radanalytics.io/kind: sparkcluster
+    radanalytics.io/kind: SparkCluster
 data:
   config: |-
     worker:

--- a/examples/test/cluster-1.yaml
+++ b/examples/test/cluster-1.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: my-spark-cluster-1
   labels:
-    radanalytics.io/kind: sparkcluster
+    radanalytics.io/kind: SparkCluster
 data:
   # this should fail
   config: |-

--- a/examples/test/cluster-2.yaml
+++ b/examples/test/cluster-2.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: my-spark-cluster-2
   labels:
-    radanalytics.io/kind: sparkcluster
+    radanalytics.io/kind: SparkCluster
 data:
   config: |-
     worker:

--- a/examples/test/cluster-with-config-1.yaml
+++ b/examples/test/cluster-with-config-1.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: sparky-cluster-1
   labels:
-    radanalytics.io/kind: sparkcluster
+    radanalytics.io/kind: SparkCluster
 data:
   config: |-
     sparkConfigurationMap: non-existent

--- a/examples/test/cluster-with-config-2.yaml
+++ b/examples/test/cluster-with-config-2.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: sparky-cluster-2
   labels:
-    radanalytics.io/kind: sparkcluster
+    radanalytics.io/kind: SparkCluster
 data:
   config: |-
     sparkConfiguration:

--- a/examples/test/cluster-with-config-3.yaml
+++ b/examples/test/cluster-with-config-3.yaml
@@ -3,6 +3,6 @@ kind: ConfigMap
 metadata:
   name: sparky-cluster-3
   labels:
-    radanalytics.io/kind: sparkcluster
+    radanalytics.io/kind: SparkCluster
 data:
   config: |-

--- a/examples/test/cr/app.yaml
+++ b/examples/test/cr/app.yaml
@@ -1,5 +1,5 @@
 apiVersion: radanalytics.io/v1
-kind: sparkapplication
+kind: SparkApplication
 metadata:
   name: my-spark-app
 spec:

--- a/examples/test/cr/cluster-2.yaml
+++ b/examples/test/cr/cluster-2.yaml
@@ -1,5 +1,5 @@
 apiVersion: radanalytics.io/v1
-kind: sparkcluster
+kind: SparkCluster
 metadata:
   name: my-spark-cluster-2
 spec:

--- a/examples/test/cr/cluster-with-config-1.yaml
+++ b/examples/test/cr/cluster-with-config-1.yaml
@@ -1,5 +1,5 @@
 apiVersion: radanalytics.io/v1
-kind: sparkcluster
+kind: SparkCluster
 metadata:
   name: sparky-cluster-1
 spec:

--- a/examples/test/cr/cluster-with-config-2.yaml
+++ b/examples/test/cr/cluster-with-config-2.yaml
@@ -1,5 +1,5 @@
 apiVersion: radanalytics.io/v1
-kind: sparkcluster
+kind: SparkCluster
 metadata:
   name: sparky-cluster-2
 spec:

--- a/examples/test/cr/cluster-with-config-3.yaml
+++ b/examples/test/cr/cluster-with-config-3.yaml
@@ -1,5 +1,5 @@
 apiVersion: radanalytics.io/v1
-kind: sparkcluster
+kind: SparkCluster
 metadata:
   name: sparky-cluster-3
 spec:

--- a/examples/with-prepared-data.yaml
+++ b/examples/with-prepared-data.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: spark-cluster-with-data
   labels:
-    radanalytics.io/kind: sparkcluster
+    radanalytics.io/kind: SparkCluster
 data:
   config: |-
     worker:

--- a/helm/spark-operator/README.md
+++ b/helm/spark-operator/README.md
@@ -32,7 +32,7 @@ kind: ConfigMap
 metadata:
   name: my-cluster
   labels:
-    radanalytics.io/kind: sparkcluster
+    radanalytics.io/kind: SparkCluster
 data:
   config: |-
     worker:
@@ -45,7 +45,7 @@ or for CRDs:
 ```
 cat <<EOF | kubectl create -f -
 apiVersion: radanalytics.io/v1
-kind: sparkcluster
+kind: SparkCluster
 metadata:
   name: my-cluster
 spec:

--- a/helm/spark-operator/templates/NOTES.txt
+++ b/helm/spark-operator/templates/NOTES.txt
@@ -7,7 +7,7 @@ kind: ConfigMap
 metadata:
   name: my-cluster
   labels:
-    radanalytics.io/kind: sparkcluster
+    radanalytics.io/kind: SparkCluster
 data:
   config: |-
     worker:
@@ -18,7 +18,7 @@ or in case of CRD approach:
 
 cat <<EOF | kubectl create -f -
 apiVersion: radanalytics.io/v1
-kind: sparkcluster
+kind: SparkCluster
 metadata:
   name: my-cluster
 spec:

--- a/manifest/olm/configmap-based-all-in-one-csv.yaml
+++ b/manifest/olm/configmap-based-all-in-one-csv.yaml
@@ -30,7 +30,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   name: sparkoperator.v0.3.3
-  annotations: 'alm-examples: [{"apiVersion": "v1","kind": "ConfigMap","metadata": {"name": "my-spark-cluster","labels": {"radanalytics.io/kind": "sparkcluster"}},"data": {"config": "worker:\n  instances: \"2\""}}]'
+  annotations: 'alm-examples: [{"apiVersion": "v1","kind": "ConfigMap","metadata": {"name": "my-spark-cluster","labels": {"radanalytics.io/kind": "SparkCluster"}},"data": {"config": "worker:\n  instances: \"2\""}}]'
 spec:
   displayName: Apache Spark Operator
   description: |
@@ -45,7 +45,7 @@ spec:
     metadata:
       name: my-spark-cluster
       labels:
-        radanalytics.io/kind: sparkcluster
+        radanalytics.io/kind: SparkCluster
     data:
       config: |-
         worker:

--- a/manifest/olm/crd/sparkapplication.crd.yaml
+++ b/manifest/olm/crd/sparkapplication.crd.yaml
@@ -7,7 +7,7 @@ spec:
   names:
     kind: SparkApplication
     listKind: SparkApplicationList
-    plural: SparkApplications
-    singular: SparkApplication
+    plural: sparkapplications
+    singular: sparkapplication
   scope: Namespaced
   version: v1

--- a/manifest/olm/crd/sparkapplication.crd.yaml
+++ b/manifest/olm/crd/sparkapplication.crd.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   group: radanalytics.io
   names:
-    kind: sparkapplication
-    listKind: sparkapplicationList
-    plural: sparkapplications
-    singular: sparkapplication
+    kind: SparkApplication
+    listKind: SparkApplicationList
+    plural: SparkApplications
+    singular: SparkApplication
   scope: Namespaced
   version: v1

--- a/manifest/olm/crd/sparkcluster.crd.yaml
+++ b/manifest/olm/crd/sparkcluster.crd.yaml
@@ -7,7 +7,7 @@ spec:
   names:
     kind: SparkCluster
     listKind: SparkClusterList
-    plural: SparkClusters
-    singular: SparkCluster
+    plural: sparkclusters
+    singular: sparkcluster
   scope: Namespaced
   version: v1

--- a/manifest/olm/crd/sparkcluster.crd.yaml
+++ b/manifest/olm/crd/sparkcluster.crd.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   group: radanalytics.io
   names:
-    kind: sparkcluster
-    listKind: sparkclusterList
-    plural: sparkclusters
-    singular: sparkcluster
+    kind: SparkCluster
+    listKind: SparkClusterList
+    plural: SparkClusters
+    singular: SparkCluster
   scope: Namespaced
   version: v1

--- a/monitoring/example-cluster-with-monitoring.yaml
+++ b/monitoring/example-cluster-with-monitoring.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: spark-cluster-with-metrics
   labels:
-    radanalytics.io/kind: sparkcluster
+    radanalytics.io/kind: SparkCluster
 data:
   config: |-
     metrics: true
@@ -21,7 +21,7 @@ spec:
     port: 7777
     protocol: TCP
   selector:
-    radanalytics.io/sparkcluster: spark-cluster-with-metrics
+    radanalytics.io/SparkCluster: spark-cluster-with-metrics
     radanalytics.io/podType: master
 ---
 apiVersion: v1
@@ -37,7 +37,7 @@ spec:
     port: 7777
     protocol: TCP
   selector:
-    radanalytics.io/sparkcluster: spark-cluster-with-metrics
+    radanalytics.io/SparkCluster: spark-cluster-with-metrics
     radanalytics.io/podType: worker
 ---
 apiVersion: v1

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <abstract-operator.version>0.5.1</abstract-operator.version>
+        <abstract-operator.version>0.5.2</abstract-operator.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This changes all sparkcluster objects to SparkCluster and all
sparkapplication to SparkApplication.

## Description
change all references to `sparkcluster` and `sparkapplication` to use the new `SparkCluster` and `SparkApplication` forms.


## Related Issue
#179 


## Types of changes

- [X ] Updated docs / Refactor code / Added a tests case / Automation (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

potentially breaking change for anyone using the older style object names.

do not merge this before, https://github.com/jvm-operators/abstract-operator/pull/29