### PR TITLE
Do not assume the myproject ns to be there

### DIFF
--- a/.travis/.travis.test-common.sh
+++ b/.travis/.travis.test-common.sh
@@ -18,7 +18,7 @@ cluster_up() {
   if [ "$BIN" = "oc" ]; then
     set -x
     oc cluster up
-    [ "$CRD" = "1" ] && oc login -u system:admin
+    [ "$CRD" = "1" ] && oc login -u system:admin && oc project default
     set +x
   else
     echo "minikube"
@@ -83,8 +83,11 @@ appErrorLogs() {
 }
 
 checkNs() {
-  # switch back to default to be able to print the logs correctly
-  [ "${BIN}" = "oc" ] && [ `oc project -q | grep -v 'default'` ] && oc project myproject || true
+  # switch back to default/myproject to be able to print the logs correctly
+  [ "${BIN}" = "oc" ] && {
+    [ "$CRD" = "0" ] && [ `oc project -q | grep -v 'myproject'` ] && oc project myproject || true
+    [ "$CRD" = "1" ] && [ `oc project -q | grep -v 'default'` ] && oc project default || true
+  } || true
 }
 
 info() {

--- a/.travis/.travis.test-common.sh
+++ b/.travis/.travis.test-common.sh
@@ -83,8 +83,8 @@ appErrorLogs() {
 }
 
 checkNs() {
-  # switch back to myproject to be able to print the logs correctly
-  [ "${BIN}" = "oc" ] && [ `oc project -q | grep -v 'myproject'` ] && oc project myproject || true
+  # switch back to default to be able to print the logs correctly
+  [ "${BIN}" = "oc" ] && [ `oc project -q | grep -v 'default'` ] && oc project myproject || true
 }
 
 info() {

--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ For deployment on OpenShift use the same commands as above, but with `oc` instea
 
 ### Custom Resource Definitions (CRD)
 
-This operator can also work with CRDs. Assuming the admin user is logged in, you can install the operator with:
+This operator can also work with CRDs. For OpenShift, we are assuming the admin user is logged in (`oc login -u system:admin`)
+ and you have switched the project to `"default"` (`oc project default`).
+
+you can install the operator with:
 
 ```bash
 kubectl apply -f manifest/operator-crd.yaml
@@ -83,6 +86,13 @@ and then create the Spark clusters by creating the custom resources (CR).
 ```bash
 kubectl apply -f examples/cluster-cr.yaml
 kubectl get SparkClusters
+```
+
+or Spark applications that are natively scheduled on Spark Clusters by:
+
+```bash
+kubectl apply -f examples/test/cr/app.yaml
+kubectl get SparkApplications
 ```
 
 ### Images

--- a/helm/spark-operator/README.md
+++ b/helm/spark-operator/README.md
@@ -63,7 +63,7 @@ _The following table lists the configurable parameters of the Spark operator cha
 | `image.repository`           | The name of the operator image                               | `quay.io/radanalyticsio/spark-operator` |
 | `image.tag`                  | The image tag representing the version of the operator       | `latest-released`                       |
 | `image.pullPolicy`           | Container image pull policy                                  | `IfNotPresent`                          |
-| `env.namespace`              | Kubernetes namespace where Spark operator watch for events. If `*` is used, it watches in all namespaces, if empty string is used, it will watch only in the same namespace the operator is deployed in.   | `""`                                    |
+| `env.namespace`              | Kubernetes namespace where Spark operator watches for events. If `*` is used, it watches in all namespaces, if empty string is used, it will watch only in the same namespace the operator is deployed in.   | `""`                                    |
 | `env.crd`                    | Whether to use CustomResource or ConfigMap based approach.   | `false`                                 |
 | `env.reconciliationInterval` | How often (in seconds) the full reconciliation should be run | `180`                                   |
 | `env.metrics`                | Whether to start metrics server to be scraped by Prometheus. | `false`                                 |

--- a/helm/spark-operator/templates/operator.yaml
+++ b/helm/spark-operator/templates/operator.yaml
@@ -17,7 +17,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: spark-operator
-    namespace: {{ default "myproject" .Values.env.namespace }}
+    namespace: {{ default "default" .Values.env.namespace }}
 {{- else }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/manifest/operator-crd.yaml
+++ b/manifest/operator-crd.yaml
@@ -8,7 +8,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: spark-operator-edit-resources
-  namespace: default
 roleRef:
   kind: ClusterRole
   name: cluster-admin
@@ -16,7 +15,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: spark-operator
-    namespace: myproject
+    namespace: default
 ---
 apiVersion: apps/v1beta1
 kind: Deployment

--- a/manifest/operator.yaml
+++ b/manifest/operator.yaml
@@ -47,7 +47,7 @@ spec:
         image: radanalyticsio/spark-operator:latest
         #env:
         #- name: WATCH_NAMESPACE # if not specified the same ns as the operator's will be used, use * for all (+ set cluster rights)
-        #  value: "myproject"
+        #  value: "default"
         #- name: FULL_RECONCILIATION_INTERVAL_S
         #  value: "180"
         #- name: CRD # if false, the operator will watch on ConfigMaps

--- a/monitoring/Monitoring.md
+++ b/monitoring/Monitoring.md
@@ -7,7 +7,8 @@ oc apply -f http://bit.ly/sparkop
 Add prometheus operator and example spark cluster that will be monitored
 ```bash
 oc login -u system:admin
-oc policy add-role-to-user edit system:serviceaccount:myproject:default
+oc project default
+oc policy add-role-to-user edit system:serviceaccount:default:default
 oc adm policy add-scc-to-user anyuid -z default
 oc apply -f monitoring/prometheus-operator.yaml
 sleep 10
@@ -17,3 +18,6 @@ oc get routes
 ```
 
 To verify the monitoring, use for instance the `jvm_memory_bytes_used` as the expression for PromQL.
+
+Note: the example above deploys all the resources into default namespace, in production, you may want to change
+the namespace to something else.

--- a/monitoring/example-cluster-with-monitoring.yaml
+++ b/monitoring/example-cluster-with-monitoring.yaml
@@ -75,7 +75,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus
-  namespace: myproject
+  namespace: default
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/monitoring/prometheus-operator.yaml
+++ b/monitoring/prometheus-operator.yaml
@@ -9,7 +9,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-operator
-  namespace: myproject
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole


### PR DESCRIPTION
Fix: #187 

For CRDs we need to create ClusterRoleBinding resource that assigns a
ClusterRole to spark-operator ServiceAccount. The service account here
needs to have also the namespace. The only namespace we can assume
to be there is the ns called 'default'. Namespace called 'myproject'
is automatically created in openshift when running oc cluster up.
With K8s or OpenShift installed via Ansible it is not the case.