### PR TITLE
simplifying the templates for GH issue and PR

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,17 +1,9 @@
-### Describe the problem:
+<!-- Provide a general summary of your changes in the Title above -->
 
-  * With couple of sentences describe the problem and its context.
+### Description:
+<!-- describe the problem or a feature request and its context -->
 
 #### Steps to reproduce:
-
-  1. 
-  2. 
-  3. 
-  
-#### Observed Results:
-
-  * What happened?  This could be a description, log output, etc.
-  
-#### Expected Results:
-
-  * What did you expect to happen?
+<!-- In case of a bug -->
+  1.
+  1.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,16 @@
 <!-- Provide a general summary of your changes in the Title above -->
+  
+### Description
 
 
-## Description
-<!-- Describe your changes in detail -->
+#### Related Issue
+<!-- if there is any -->
 
 
-## Related Issue
-<!-- Reference the related issue by using Issue #42 syntax of use the Fix #42 in one of the commits -->
+#### Types of changes
+<!-- Use ONLY ONE that applies (and delete the rest) -->
 
-
-## Types of changes
-<!-- What types of changes does your code introduce? Put an `x` in one box that applies: -->
-
-- [ ] Updated docs / Refactor code / Added a tests case / Automation (non-breaking change)
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+ :bulb: Updated docs / Refactor code / Added a tests case / Automation (non-breaking change)
+ :bug: Bug fix (non-breaking change which fixes an issue)
+ :sparkles: New feature (non-breaking change which adds functionality)
+ :warning: Breaking change (fix or feature that would cause existing functionality to change)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
  
### Description
Changing the template for newly created PRs and issues to make it simpler and give contributors more freedom and "less processes". Also the check box approach for the type of change was awful, because GH was interpreting as a todo list.

@elmiko could you please take a look? Should it be even simpler?

#### Types of changes
<!-- Use ONLY ONE that applies (and delete the rest) -->

 :bulb: Updated docs / Refactor code / Added a tests case / Automation (non-breaking change)