### PR TITLE
Make the spark ui optional (default=enabled)

### DIFF
--- a/examples/cluster-with-config.yaml
+++ b/examples/cluster-with-config.yaml
@@ -15,7 +15,8 @@ data:
       memory: "1Gi"                                       # optional no defaults
       cpu: 0.2                                            # optional no defaults
     customImage: quay.io/jkremser/openshift-spark:2.4.0   # optional defaults to quay.io/jkremser/openshift-spark:2.4.0
-    metrics: true                                         # on each pod expose the metrics endpoint on port 7777 for prometheus
+    metrics: false                                        # on each pod expose the metrics endpoint on port 7777 for prometheus, defautls to false
+    sparkWebUI: true                                      # create a service with the Spark UI, defautls to true
     env:                                                  # optional
     - name: SPARK_WORKER_CORES
       value: 2

--- a/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
+++ b/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
@@ -38,8 +38,12 @@ public class KubernetesSparkClusterDeployer {
             ReplicationController masterRc = getRCforMaster(cluster);
             ReplicationController workerRc = getRCforWorker(cluster);
             Service masterService = getService(false, name, 7077, allMasterLabels);
-            Service masterUiService = getService(true, name, 8080, allMasterLabels);
-            KubernetesList resources = new KubernetesListBuilder().withItems(masterRc, workerRc, masterService, masterUiService).build();
+            List<HasMetadata> list = new ArrayList<>(Arrays.asList(masterRc, workerRc, masterService));
+            if (cluster.getSparkWebUI()) {
+                Service masterUiService = getService(true, name, 8080, allMasterLabels);
+                list.add(masterUiService);
+            }
+            KubernetesList resources = new KubernetesListBuilder().withItems(list).build();
             return resources;
         }
     }
@@ -82,14 +86,18 @@ public class KubernetesSparkClusterDeployer {
         });
         if (isMaster) {
             ContainerPort apiPort = new ContainerPortBuilder().withName("spark-master").withContainerPort(7077).withProtocol("TCP").build();
-            ContainerPort uiPort = new ContainerPortBuilder().withName("spark-webui").withContainerPort(8080).withProtocol("TCP").build();
             ports.add(apiPort);
-            ports.add(uiPort);
+            if (cluster.getSparkWebUI()) {
+                ContainerPort uiPort = new ContainerPortBuilder().withName("spark-webui").withContainerPort(8080).withProtocol("TCP").build();
+                ports.add(uiPort);
+            }
         } else {
-            ContainerPort uiPort = new ContainerPortBuilder().withName("spark-webui").withContainerPort(8081).withProtocol("TCP").build();
-            ports.add(uiPort);
             envVars.add(env("SPARK_MASTER_ADDRESS", "spark://" + name + ":7077"));
-            envVars.add(env("SPARK_MASTER_UI_ADDRESS", "http://" + name + "-ui:8080"));
+            if (cluster.getSparkWebUI()) {
+                ContainerPort uiPort = new ContainerPortBuilder().withName("spark-webui").withContainerPort(8081).withProtocol("TCP").build();
+                ports.add(uiPort);
+                envVars.add(env("SPARK_MASTER_UI_ADDRESS", "http://" + name + "-ui:8080"));
+            }
         }
         if (cluster.getMetrics()) {
             envVars.add(env("SPARK_METRICS_ON", "prometheus"));
@@ -104,11 +112,9 @@ public class KubernetesSparkClusterDeployer {
                 .withSuccessThreshold(1)
                 .withTimeoutSeconds(1).build();
 
-        Probe generalProbe = new ProbeBuilder().withFailureThreshold(3).withNewHttpGet()
-                .withPath("/")
-                .withNewPort().withIntVal(isMaster ? 8080 : 8081).endPort()
-                .withScheme("HTTP")
-                .endHttpGet()
+        Probe generalProbe = new ProbeBuilder().withFailureThreshold(3).withNewTcpSocket()
+                .withNewPort().withIntVal(7077).endPort()
+                .endTcpSocket()
                 .withPeriodSeconds(10)
                 .withSuccessThreshold(1)
                 .withInitialDelaySeconds(8 + cluster.getDownloadData().size() * 5)
@@ -148,7 +154,7 @@ public class KubernetesSparkClusterDeployer {
         if (isMaster) {
             containerBuilder = containerBuilder.withReadinessProbe(generalProbe).withLivenessProbe(masterLiveness);
         } else {
-            containerBuilder.withLivenessProbe(generalProbe);
+            //containerBuilder.withLivenessProbe(generalProbe);
         }
 
         Map<String, String> labels = getDefaultLabels(name);

--- a/src/main/java/io/radanalytics/operator/cluster/SparkClusterOperator.java
+++ b/src/main/java/io/radanalytics/operator/cluster/SparkClusterOperator.java
@@ -185,6 +185,15 @@ public class SparkClusterOperator extends AbstractOperator<SparkCluster> {
         return deployer;
     }
 
+    /**
+     * This method verifies if any two instances of SparkCluster are the same ones up to the number of
+     * workers. This way we can call the scale instead of recreating the whole cluster.
+     *
+     * @param oldC the first instance of SparkCluster we are comparing
+     * @param newC the second instance of SparkCluster we are comparing
+     * @return true if both instances represent the same spark cluster but differs only in number of workers (it is safe
+     * to call scale method)
+     */
     private boolean isOnlyScale(SparkCluster oldC, SparkCluster newC) {
         boolean retVal = oldC.getWorker().getInstances() != newC.getWorker().getInstances();
         int backup = Optional.ofNullable(newC.getWorker()).orElse(new RCSpec()).getInstances();

--- a/src/main/resources/schema/sparkCluster.json
+++ b/src/main/resources/schema/sparkCluster.json
@@ -21,6 +21,10 @@
       "type": "boolean",
       "default": "false"
     },
+    "sparkWebUI": {
+      "type": "boolean",
+      "default": "true"
+    },
     "sparkConfigurationMap": {
       "type": "string"
     },


### PR DESCRIPTION
### Description
new boolean option in the CM or CR called `sparkWebUI`

todo: readiness probe logic, because it depended on the spark ui (it's done for master based on the open socket check), but it needs to be done also for workers, ideally by checking the log files if they were able to connect to the master


#### Related Issue
Issue #171 


#### Types of changes
<!-- Use ONLY ONE that applies (and delete the rest) -->
 :sparkles: New feature (non-breaking change which adds functionality)
