### PR TITLE
change default spark image mechanics

### DIFF
--- a/src/main/java/io/radanalytics/operator/Constants.java
+++ b/src/main/java/io/radanalytics/operator/Constants.java
@@ -2,8 +2,16 @@ package io.radanalytics.operator;
 
 public class Constants {
 
-    public static String DEFAULT_SPARK_IMAGE = "quay.io/jkremser/openshift-spark:2.4.0";
+    public static String DEFAULT_SPARK_IMAGE = "quay.io/radanalyticsio/openshift-spark:latest";
     public static final String OPERATOR_TYPE_UI_LABEL = "ui";
     public static final String OPERATOR_TYPE_MASTER_LABEL = "master";
     public static final String OPERATOR_TYPE_WORKER_LABEL = "worker";
+
+    public static String getDefaultSparkImage() { 
+        String ret = DEFAULT_SPARK_IMAGE;
+        if (System.getenv("DEFAULT_SPARK_CLUSTER_IMAGE") != null) {
+            ret = System.getenv("DEFAULT_SPARK_CLUSTER_IMAGE");
+        }
+        return ret;
+    }
 }

--- a/src/main/java/io/radanalytics/operator/Constants.java
+++ b/src/main/java/io/radanalytics/operator/Constants.java
@@ -2,7 +2,7 @@ package io.radanalytics.operator;
 
 public class Constants {
 
-    public static String DEFAULT_SPARK_IMAGE = "quay.io/radanalyticsio/openshift-spark:latest";
+    public static String DEFAULT_SPARK_IMAGE = "quay.io/jkremser/openshift-spark:2.4.0";
     public static final String OPERATOR_TYPE_UI_LABEL = "ui";
     public static final String OPERATOR_TYPE_MASTER_LABEL = "master";
     public static final String OPERATOR_TYPE_WORKER_LABEL = "worker";

--- a/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
+++ b/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
@@ -114,7 +114,12 @@ public class KubernetesSparkClusterDeployer {
                 .withInitialDelaySeconds(8 + cluster.getDownloadData().size() * 5)
                 .withTimeoutSeconds(1).build();
 
-        ContainerBuilder containerBuilder = new ContainerBuilder().withEnv(envVars).withImage(cluster.getCustomImage())
+        String imageRef = getDefaultSparkImage(); // from Constants
+        if (cluster.getCustomImage() != null) {
+            imageRef = cluster.getCustomImage();
+        }
+
+        ContainerBuilder containerBuilder = new ContainerBuilder().withEnv(envVars).withImage(imageRef)
                 .withImagePullPolicy("IfNotPresent")
                 .withName(name + (isMaster ? "-m" : "-w"))
                 .withTerminationMessagePath("/dev/termination-log")

--- a/src/main/java/io/radanalytics/operator/cluster/SparkClusterOperator.java
+++ b/src/main/java/io/radanalytics/operator/cluster/SparkClusterOperator.java
@@ -14,6 +14,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.radanalytics.operator.common.AbstractOperator;
 import io.radanalytics.operator.common.Operator;
+import io.radanalytics.operator.Constants;
 import io.radanalytics.types.RCSpec;
 import io.radanalytics.types.SparkCluster;
 import org.slf4j.Logger;
@@ -35,6 +36,11 @@ public class SparkClusterOperator extends AbstractOperator<SparkCluster> {
 
     private RunningClusters clusters;
     private KubernetesSparkClusterDeployer deployer;
+
+    @Override
+    protected void onInit() {
+        log.info("{} operator default spark image = {}", this.entityName, Constants.getDefaultSparkImage());
+    }
 
     @Override
     protected void onAdd(SparkCluster cluster) {

--- a/src/main/resources/schema/sparkCluster.json
+++ b/src/main/resources/schema/sparkCluster.json
@@ -14,8 +14,7 @@
       "$ref": "#/definitions/RCSpec"
     },
     "customImage": {
-      "type": "string",
-      "default": "quay.io/jkremser/openshift-spark:2.4.0"
+      "type": "string"
     },
     "metrics": {
       "type": "boolean",

--- a/src/test/java/io/radanalytics/operator/resource/YamlProcessingTest.java
+++ b/src/test/java/io/radanalytics/operator/resource/YamlProcessingTest.java
@@ -83,7 +83,7 @@ public class YamlProcessingTest {
 
         assertEquals(clusterInfo.getName(), "foo");
         assertEquals(clusterInfo.getWorker().getInstances().intValue(), 2);
-        assertEquals(clusterInfo.getCustomImage(), DEFAULT_SPARK_IMAGE);
+        assertEquals(clusterInfo.getCustomImage(), null);
     }
 
     @Test

--- a/src/test/java/io/radanalytics/operator/resource/YamlProcessingTest.java
+++ b/src/test/java/io/radanalytics/operator/resource/YamlProcessingTest.java
@@ -14,7 +14,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import static io.radanalytics.operator.Constants.DEFAULT_SPARK_IMAGE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;


### PR DESCRIPTION
## Description

This change makes it possible to set the default spark image through an
environment variable in the operator container. It also changes the
default image specified inside the code to
`quay.io/radanalyticsio/openshift-spark:latest` and removes the default
image ref from the schema spec.


## Related Issue
#186 

## Types of changes

- [ ] Updated docs / Refactor code / Added a tests case / Automation (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
