### PR TITLE
Allow changing the deployment and watched namespace

### DIFF
--- a/helm/spark-operator/templates/operator.yaml
+++ b/helm/spark-operator/templates/operator.yaml
@@ -17,7 +17,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: spark-operator
-    namespace: "{{ default "default" .Values.env.namespace }}"
+    namespace: "{{ .Release.Namespace }}"
 {{- else }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/helm/spark-operator/templates/operator.yaml
+++ b/helm/spark-operator/templates/operator.yaml
@@ -17,7 +17,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: spark-operator
-    namespace: {{ default "default" .Values.env.namespace }}
+    namespace: "{{ default "default" .Values.env.namespace }}"
 {{- else }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -67,7 +67,7 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         env:
         - name: WATCH_NAMESPACE
-          value: {{ .Values.env.namespace }}
+          value: "{{ .Values.env.namespace }}"
         - name: FULL_RECONCILIATION_INTERVAL_S
           value: "{{ .Values.env.reconciliationInterval }}"
         - name: CRD


### PR DESCRIPTION
Prevent that specifying * as namespace leads to an error while installing Helm chart

## Description

I was only able to install the Helm chart after adding quotes to the namespace value. We are using a YAML file to set the values that looks like this:

```
env:
  # Use CustomResoruce instead of ConfigMap
  crd: true
  # Watch all namespaces
  namespace: "*"
```

## Related Issue

## Types of changes

- [ ] Updated docs / Refactor code / Added a tests case / Automation (non-breaking change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
