### PR TITLE
Liveness probe for workers

### DIFF
--- a/.travis/.travis.test-common.sh
+++ b/.travis/.travis.test-common.sh
@@ -114,6 +114,13 @@ testCreateCluster1() {
   os::cmd::try_until_text "${BIN} get pod -l radanalytics.io/deployment=my-spark-cluster-m -o yaml" 'ready: true'
 }
 
+testNoPodRestartsOccurred() {
+  info
+  _CLUSTER=${1}
+  os::cmd::try_until_text "${BIN} get pod -l radanalytics.io/deployment=${_CLUSTER}-w -o yaml" 'restartCount: 0' && \
+  os::cmd::try_until_text "${BIN} get pod -l radanalytics.io/deployment=${_CLUSTER}-m -o yaml" 'restartCount: 0'
+}
+
 testScaleCluster() {
   info
   if [ "$CRD" = "1" ]; then

--- a/.travis/.travis.test-oc-and-k8s.sh
+++ b/.travis/.travis.test-oc-and-k8s.sh
@@ -24,6 +24,8 @@ run_custom_test() {
 run_tests() {
   testCreateCluster1 || errorLogs
   testScaleCluster || errorLogs
+  sleep 45
+  testNoPodRestartsOccurred "my-spark-cluster" || errorLogs
   testDeleteCluster || errorLogs
   sleep 5
 
@@ -50,7 +52,7 @@ run_tests() {
 }
 
 main() {
-  export total=19
+  export total=20
   export testIndex=0
   tear_down
   setup_testing_framework

--- a/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
+++ b/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
@@ -112,7 +112,8 @@ public class KubernetesSparkClusterDeployer {
                 .withSuccessThreshold(1)
                 .withTimeoutSeconds(1).build();
 
-        Probe workerLiveness = new ProbeBuilder().withNewExec().withCommand(Arrays.asList("/bin/bash", "-c", "curl -s localhost:8081 | grep -e 'Master URL:.*spark://'")).endExec()
+        Probe workerLiveness = new ProbeBuilder().withNewExec().withCommand(Arrays.asList("/bin/bash", "-c", "curl -s localhost:8081 | grep -e 'Master URL:.*spark://'" +
+                " || echo Unable to connect to the Spark master at $SPARK_MASTER_ADDRESS")).endExec()
                 .withFailureThreshold(3)
                 .withInitialDelaySeconds(4 + cluster.getDownloadData().size() * 5)
                 .withPeriodSeconds(10)

--- a/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
+++ b/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
@@ -105,14 +105,14 @@ public class KubernetesSparkClusterDeployer {
             ports.add(metricsPort);
         }
 
-        Probe masterLiveness = new ProbeBuilder().withNewExec().withCommand(Arrays.asList("/bin/bash", "-c", "curl localhost:8080 | grep -e Status.*ALIVE")).endExec()
+        Probe masterLiveness = new ProbeBuilder().withNewExec().withCommand(Arrays.asList("/bin/bash", "-c", "curl -s localhost:8080 | grep -e Status.*ALIVE")).endExec()
                 .withFailureThreshold(3)
                 .withInitialDelaySeconds(4 + cluster.getDownloadData().size() * 5)
                 .withPeriodSeconds(10)
                 .withSuccessThreshold(1)
                 .withTimeoutSeconds(1).build();
 
-        Probe workerLiveness = new ProbeBuilder().withNewExec().withCommand(Arrays.asList("/bin/bash", "-c", "curl localhost:8081 | grep -e 'Master URL:[^<]+'")).endExec()
+        Probe workerLiveness = new ProbeBuilder().withNewExec().withCommand(Arrays.asList("/bin/bash", "-c", "curl -s localhost:8081 | grep -e 'Master URL:.*spark://'")).endExec()
                 .withFailureThreshold(3)
                 .withInitialDelaySeconds(4 + cluster.getDownloadData().size() * 5)
                 .withPeriodSeconds(10)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

I was assuming that the curl returns something like: `<strong>Master URL: spark://172.17.0.7:7077</strong>` but it's not the case, it returns: `<strong>Master URL:</strong> spark://172.17.0.7:7077`. Travis was ok with the change, because the workers reported themselves as ready (readiness probe passed) and they passed the checks in travis, but when running the cluster for a minute it wasn't ok.

This PR also adds `-s` for the liveness probe for master, because what's important is the return code of the command and w/o the `-s` the curl returns that ugly header (also in `oc get events` output).
  
### Description
```
sh-4.2$ curl -s localhost:8081 | grep -e 'Master URL:.*spark://'
              Master URL:</strong> spark://172.17.0.7:7077
sh-4.2$ echo $?
0
```

#### Related Issue
Fix #198 


#### Types of changes
<!-- Use ONLY ONE that applies (and delete the rest) -->

 :bug: Bug fix (non-breaking change which fixes an issue)

@elmiko could you please take a look?

UPDATE:
```
2019-02-25 14:36:10 +0100 CET   2019-02-25 14:03:45 +0100 CET   7         my-spark-cluster-w-wdln2         Pod                     spec.containers{my-spark-cluster-w}   Warning   Unhealthy               kubelet, localhost       Liveness probe failed:
```
^ it should print something