### PR TITLE
Init containers fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ that targets Apache Spark.
 Show the log:
 
 ```bash
+# last 25 log entries
+kubectl logs --tail 25 -l app.kubernetes.io/name=spark-operator
+```
+
+```bash
+# follow logs
 kubectl logs -f `kubectl get pod -l app.kubernetes.io/name=spark-operator -o='jsonpath="{.items[0].metadata.name}"' | sed 's/"//g'`
 ```
 

--- a/examples/cluster-with-config.yaml
+++ b/examples/cluster-with-config.yaml
@@ -23,9 +23,9 @@ spec:
                                                       # kubectl create configmap my-config --from-file=example/config.conf
   sparkConfiguration:                                 # optional, it overrides the config defined above
   - name: spark.executor.memory
-    value: 1g
+    value: 0.5g
   - name: spark.sql.conf.autoBroadcastJoinThreshold
     value: 20971520
   downloadData:                                       # optional, it downloads these files to each node
-  - url: https://raw.githubusercontent.com/Jiri-Kremser/spark-operator/master/README.md
+  - url: https://raw.githubusercontent.com/radanalyticsio/spark-operator/master/README.md
     to: /tmp/

--- a/examples/test/cluster-with-config-1.yaml
+++ b/examples/test/cluster-with-config-1.yaml
@@ -8,5 +8,5 @@ spec:
   - name: spark.executor.memory
     value: 1g
   downloadData:
-  - url: https://raw.githubusercontent.com/Jiri-Kremser/spark-operator/master/README.md
+  - url: https://raw.githubusercontent.com/radanalyticsio/spark-operator/master/README.md
     to: /tmp/

--- a/examples/test/cm/cluster-with-config-1.yaml
+++ b/examples/test/cm/cluster-with-config-1.yaml
@@ -11,5 +11,5 @@ data:
     - name: spark.executor.memory
       value: 1g
     downloadData:
-    - url: https://raw.githubusercontent.com/Jiri-Kremser/spark-operator/master/README.md
+    - url: https://raw.githubusercontent.com/radanalyticsio/spark-operator/master/README.md
       to: /tmp/

--- a/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
+++ b/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
@@ -1,0 +1,239 @@
+package io.radanalytics.operator.cluster;
+
+import io.fabric8.kubernetes.api.model.*;
+import io.radanalytics.types.DownloadDatum;
+import io.radanalytics.types.SparkCluster;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static io.radanalytics.operator.Constants.getDefaultSparkImage;
+
+public class InitContainersHelper {
+
+    private static final String NEW_CONF_DIR = "conf-new-dir";
+    private static final String NEW_CONF_DIR_PATH = "/tmp/config/new";
+    private static final String DEFAULT_CONF_DIR_PATH = "/opt/spark/conf";
+
+    /**
+     * Based on the SparkCluster configuration, it can add init-containers called 'downloader', 'backup-config' and/or
+     * 'override-config'. The firs one will be added if the <code>cluster.getDownloadData()</code> is not empty, while the
+     * latter two are always being added together if config map that overrides the default spark configuration exist in the
+     * K8s or if the <code>cluster.getSparkConfiguration()</code> is not empty.
+     *
+     * Optionally adds the init containers that do:
+     * <ol>
+     *     <li>downloads the data with curl if it's specified</li>
+     *     <li>backups the original (default) Spark configuration into <code>NEW_CONF_DIR_PATH</code></li>
+     *     <li>copies/replaces the config files in the <code>NEW_CONF_DIR_PATH</code> with the files coming from the config map</li>
+     *     <li>overrides (/appends) the key-value entries in the <code>NEW_CONF_DIR_PATH/spark-defaults.conf</code></li>
+     *     <li>use the configuration <code>NEW_CONF_DIR_PATH</code> as the configuration for the spark</li>
+     * </ol>
+     *
+     *
+     * @param rc ReplicationController instance
+     * @param cluster SparkCluster instance
+     * @param cmExists whether config map with overrides exists
+     * @return modified ReplicationController instance
+     */
+    public static final ReplicationController addInitContainers(ReplicationController rc,
+                                                                 SparkCluster cluster,
+                                                                 boolean cmExists) {
+        PodSpec podSpec = rc.getSpec().getTemplate().getSpec();
+
+        if (!cluster.getDownloadData().isEmpty()) {
+            createDownloader(cluster, podSpec);
+        }
+        if (cmExists || !cluster.getSparkConfiguration().isEmpty()) {
+            createBackupContainer(cluster, podSpec);
+            createConfigOverrideContainer(cluster, podSpec, cmExists);
+        }
+
+        rc.getSpec().getTemplate().setSpec(podSpec);
+        return rc;
+    }
+
+    private static Container createDownloader(SparkCluster cluster, PodSpec podSpec) {
+        final String mountName = "data-dir";
+        final String mountPath = "/tmp/";
+        final VolumeMount downloadMount = new VolumeMountBuilder().withName(mountName).withMountPath(mountPath).build();
+        final Volume downloadVolume = new VolumeBuilder().withName(mountName).withNewEmptyDir().endEmptyDir().build();
+        final List<DownloadDatum> downloadData = cluster.getDownloadData();
+        final StringBuilder downloaderCmd = new StringBuilder();
+        downloadData.forEach(dl -> {
+            String url = dl.getUrl();
+            String to = dl.getTo();
+            // if 'to' ends with slash, we know it's a directory and we use the -P switch to change the prefix,
+            // otherwise using -O for renaming the downloaded file
+            String param = to.endsWith("/") ? " -P " : " -O ";
+            downloaderCmd.append("wget ");
+            downloaderCmd.append(url);
+            downloaderCmd.append(param);
+            downloaderCmd.append(to);
+        });
+
+        Container downloader = new ContainerBuilder()
+                .withName("downloader")
+                .withImage("busybox")
+                .withImagePullPolicy("IfNotPresent")
+                .withCommand("/bin/sh", "-xc")
+                .withArgs(downloaderCmd.toString())
+                .withVolumeMounts(downloadMount)
+                .build();
+
+
+        podSpec.getContainers().get(0).getVolumeMounts().add(downloadMount);
+        podSpec.getVolumes().add(downloadVolume);
+        podSpec.getInitContainers().add(downloader);
+
+        return downloader;
+    }
+
+    private static Container createBackupContainer(SparkCluster cluster, PodSpec podSpec) {
+        final VolumeMount backupMount = new VolumeMountBuilder().withName(NEW_CONF_DIR).withMountPath(NEW_CONF_DIR_PATH).build();
+        final Volume backupVolume = new VolumeBuilder().withName(NEW_CONF_DIR).withNewEmptyDir().endEmptyDir().build();
+
+        Container backup = new ContainerBuilder()
+                .withName("backup-config")
+                .withImage(Optional.ofNullable(cluster.getCustomImage()).orElse(getDefaultSparkImage()))
+                .withCommand("/bin/sh", "-xc")
+                .withArgs("cp -r " + DEFAULT_CONF_DIR_PATH + "/* " + NEW_CONF_DIR_PATH)
+                .withVolumeMounts(backupMount)
+                .build();
+
+
+        podSpec.getContainers().get(0).getVolumeMounts().add(backupMount);
+        podSpec.getVolumes().add(backupVolume);
+        podSpec.getInitContainers().add(backup);
+
+        return backup;
+    }
+
+    private static Container createConfigOverrideContainer(SparkCluster cluster, PodSpec podSpec, boolean cmExists) {
+        final List<io.radanalytics.types.NameValue> config = cluster.getSparkConfiguration();
+        String cmMountName = "configmap-dir";
+        String cmMountPath = "/tmp/config/fromCM";
+        List<VolumeMount> mounts = new ArrayList<>(2);
+        if (cmExists) {
+            String cmName = getExpectedCMName(cluster);
+
+            final VolumeMount cmMount = new VolumeMountBuilder().withName(cmMountName).withMountPath(cmMountPath).build();
+            final Volume cmVolume = new VolumeBuilder().withName(cmMountName).withNewConfigMap().withName(cmName).endConfigMap().build();
+            podSpec.getVolumes().add(cmVolume);
+            mounts.add(cmMount);
+        }
+
+        final VolumeMount backupMount = new VolumeMountBuilder().withName(NEW_CONF_DIR).withMountPath(NEW_CONF_DIR_PATH).build();
+        final String origConfMountName = "conf-orig-dir";
+        final VolumeMount origConfMount = new VolumeMountBuilder().withName(origConfMountName).withMountPath(DEFAULT_CONF_DIR_PATH).build();
+        final Volume origConfVolume = new VolumeBuilder().withName(origConfMountName).withNewEmptyDir().endEmptyDir().build();
+        mounts.add(backupMount);
+        mounts.add(origConfMount);
+
+        final StringBuilder overrideConfigCmd = new StringBuilder();
+        if (cmExists) {
+            // add/replace the content of NEW_CONF_DIR_PATH with all the files that comes from the config map
+            overrideConfigCmd.append("cp -r ");
+            overrideConfigCmd.append(cmMountPath);
+            overrideConfigCmd.append("/* ");
+            overrideConfigCmd.append(NEW_CONF_DIR_PATH);
+            if (!config.isEmpty()) {
+                overrideConfigCmd.append(" ; ");
+            }
+        }
+
+        if (!config.isEmpty()) {
+            // override the key-value entries in the spark-defaults.conf
+            overrideConfigCmd.append("echo -e \"");
+            config.forEach(kv -> {
+                overrideConfigCmd.append(kv.getName());
+                overrideConfigCmd.append(" ");
+                overrideConfigCmd.append(kv.getValue());
+                overrideConfigCmd.append("\\n");
+            });
+            overrideConfigCmd.append("\" >> ");
+            overrideConfigCmd.append(NEW_CONF_DIR_PATH);
+            overrideConfigCmd.append("/spark-defaults.conf");
+        }
+
+        // replace the content of /opt/spark/conf with the newly created config files
+        overrideConfigCmd.append(" && cp -r ");
+        overrideConfigCmd.append(NEW_CONF_DIR_PATH);
+        overrideConfigCmd.append("/* ");
+        overrideConfigCmd.append(DEFAULT_CONF_DIR_PATH);
+
+        Container overrideConfig = new ContainerBuilder()
+                .withName("override-config")
+                .withImage("busybox")
+                .withImagePullPolicy("IfNotPresent")
+                .withCommand("/bin/sh", "-xc")
+                .withArgs(overrideConfigCmd.toString())
+                .withVolumeMounts(mounts)
+                .build();
+
+        podSpec.getInitContainers().add(overrideConfig);
+        podSpec.getContainers().get(0).getVolumeMounts().add(origConfMount);
+        podSpec.getVolumes().add(origConfVolume);
+
+        return overrideConfig;
+    }
+
+    /**
+     * Returns the <code>cluster.getSparkConfigurationMap()</code> if it's there. If not, it defaults to the
+     * name of the spark cluster concatenated with <code>'-config'</code> suffix.
+     *
+     * @param cluster SparkCluster instance
+     * @return expected name of the config map
+     */
+    public static String getExpectedCMName(SparkCluster cluster) {
+        return cluster.getSparkConfigurationMap() == null ? cluster.getName() + "-config" : cluster.getSparkConfigurationMap();
+    }
+
+    /**
+     * Calculates the expected initial delay for the liveness or readiness probe for master or worker
+     * it considers these attributes:
+     * <ul>
+     *  <li>if there is anything to download</li>
+     *  <li>if config map with overrides exists</li>
+     *  <li>if key-value config entries were passed in the custom resource/CM</li>
+     *  <li>cpu limit</li>
+     * </ul>
+     *
+     * Also worker node gets some minor penalisation, because its probe depends on the master's readiness.
+     *
+     * @param cluster SparkCluster instance
+     * @param cmExists if config map with overrides exists
+     * @param isMaster whether it is master or worker
+     * @return expected time for initial delay for the probes
+     */
+    public static int getExpectedDelay(SparkCluster cluster, boolean cmExists, boolean isMaster) {
+        int delay = 5;
+        if (isMaster) {
+            if (null != cluster.getMaster() && null != cluster.getMaster().getCpu()) {
+                try {
+                    double cpu = Double.parseDouble(cluster.getMaster().getCpu());
+                    delay += (1.0 / cpu) * 3;
+                } catch (NumberFormatException nfe) {
+                    // ignore
+                }
+            }
+            delay += 0;
+        } else {
+            if (null != cluster.getWorker() && null != cluster.getWorker().getCpu()) {
+                try {
+                    double cpu = Double.parseDouble(cluster.getWorker().getCpu());
+                    delay += (1.0 / cpu) * 3;
+                } catch (NumberFormatException nfe) {
+                    // ignore
+                }
+            }
+            delay += 4;
+        }
+        delay += cmExists ? 3 : 0;
+        delay += !cluster.getSparkConfiguration().isEmpty() ? 3 : 0;
+        delay += cluster.getDownloadData().size() * 4;
+        return delay;
+    }
+
+}

--- a/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
+++ b/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
@@ -137,7 +137,7 @@ public class InitContainersHelper {
             // add/replace the content of NEW_CONF_DIR_PATH with all the files that comes from the config map
             overrideConfigCmd.append("cp -r ");
             overrideConfigCmd.append(cmMountPath);
-            overrideConfigCmd.append("/* ");
+            overrideConfigCmd.append("/..data/* ");
             overrideConfigCmd.append(NEW_CONF_DIR_PATH);
             if (!config.isEmpty()) {
                 overrideConfigCmd.append(" ; ");

--- a/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
+++ b/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
@@ -71,6 +71,7 @@ public class InitContainersHelper {
             downloaderCmd.append(url);
             downloaderCmd.append(param);
             downloaderCmd.append(to);
+            downloaderCmd.append(" ; ");
         });
 
         Container downloader = new ContainerBuilder()

--- a/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
+++ b/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
@@ -209,12 +209,12 @@ public class InitContainersHelper {
      * @return expected time for initial delay for the probes
      */
     public static int getExpectedDelay(SparkCluster cluster, boolean cmExists, boolean isMaster) {
-        int delay = 5;
+        int delay = 6;
         if (isMaster) {
             if (null != cluster.getMaster() && null != cluster.getMaster().getCpu()) {
                 try {
                     double cpu = Double.parseDouble(cluster.getMaster().getCpu());
-                    delay += (1.0 / cpu) * 3;
+                    delay += (1.0 / cpu) * 3.5;
                 } catch (NumberFormatException nfe) {
                     // ignore
                 }
@@ -224,7 +224,7 @@ public class InitContainersHelper {
             if (null != cluster.getWorker() && null != cluster.getWorker().getCpu()) {
                 try {
                     double cpu = Double.parseDouble(cluster.getWorker().getCpu());
-                    delay += (1.0 / cpu) * 3;
+                    delay += (1.0 / cpu) * 3.5;
                 } catch (NumberFormatException nfe) {
                     // ignore
                 }

--- a/src/main/java/io/radanalytics/operator/cluster/MetricsHelper.java
+++ b/src/main/java/io/radanalytics/operator/cluster/MetricsHelper.java
@@ -6,27 +6,27 @@ import io.prometheus.client.Gauge;
 public class MetricsHelper {
     private static final String PREFIX = "operator_";
 
-        public static final Counter reconciliationsTotal = Counter.build()
-                .name(PREFIX + "full_reconciliations_total")
-                .help("How many times the full reconciliation has been run.")
-                .labelNames("ns")
-                .register();
+    public static final Counter reconciliationsTotal = Counter.build()
+            .name(PREFIX + "full_reconciliations_total")
+            .help("How many times the full reconciliation has been run.")
+            .labelNames("ns")
+            .register();
 
-        public static final Gauge runningClusters = Gauge.build()
-                .name(PREFIX + "running_clusters")
-                .help("Spark clusters that are currently running.")
-                .labelNames("ns")
-                .register();
+    public static final Gauge runningClusters = Gauge.build()
+            .name(PREFIX + "running_clusters")
+            .help("Spark clusters that are currently running.")
+            .labelNames("ns")
+            .register();
 
-        public static final Gauge workers = Gauge.build()
-                .name(PREFIX + "running_workers")
-                .help("Number of workers per cluster name.")
-                .labelNames("cluster", "ns")
-                .register();
+    public static final Gauge workers = Gauge.build()
+            .name(PREFIX + "running_workers")
+            .help("Number of workers per cluster name.")
+            .labelNames("cluster", "ns")
+            .register();
 
-        public static final Gauge startedTotal = Gauge.build()
-                .name(PREFIX + "started_clusters_total")
-                .help("Spark clusters has been started by operator.")
-                .labelNames("ns")
-                .register();
+    public static final Gauge startedTotal = Gauge.build()
+            .name(PREFIX + "started_clusters_total")
+            .help("Spark clusters has been started by operator.")
+            .labelNames("ns")
+            .register();
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
  
### Description
Now when overriding the default Spark configuration, the mount will not shadow the other content in that directory anymore. This was the root cause for the #192 . Now the logic is as follows:

     * Optionally adds the init containers that do:
     * <ol>
     *     <li>downloads the data with curl if it's specified</li>
     *     <li>backups the original (default) Spark configuration into <code>NEW_CONF_DIR_PATH</code></li>
     *     <li>copies/replaces the config files in the <code>NEW_CONF_DIR_PATH</code> with the files coming from the config map</li>
     *     <li>overrides (/appends) the key-value entries in the <code>NEW_CONF_DIR_PATH/spark-defaults.conf</code></li>
     *     <li>use the configuration <code>NEW_CONF_DIR_PATH</code> as the configuration for the spark</li>
     * </ol>

where     `NEW_CONF_DIR_PATH` = `/tmp/config/new`
    `DEFAULT_CONF_DIR_PATH` = `/opt/spark/conf`

#### Related Issue
#192 

#### Types of changes
<!-- Use ONLY ONE that applies (and delete the rest) -->

 :bug: Bug fix (non-breaking change which fixes an issue)
