### PR TITLE
change SparkApplication default image mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,23 @@ Image name         | Description | Layers | quay.io | docker.io
 
 For each variant there is also available an image with `-alpine` suffix based on Alpine for instance [![Layers info](https://images.microbadger.com/badges/image/radanalyticsio/spark-operator:latest-released-alpine.svg)](https://microbadger.com/images/radanalyticsio/spark-operator:latest-released-alpine)
 
+### Configuring the operator
+
+The spark-operator contains several defaults that are implicit to the creation
+of Spark clusters and applications. Here are a list of environment variables
+that can be set to adjust the default behaviors of the operator.
+
+* `CRD` set to `true` if the operator the operator should respond to Custom
+  Resource Definitions, and set to `false` if it should respone to ConfigMaps.
+* `DEFAULT_SPARK_CLUSTER_IMAGE` a container image reference that will be used
+  for all pods in a `SparkCluster` deployment.
+* `DEFAULT_SPARK_APP_IMAGE` a container image reference that will be used for
+  all executor pods in a `SparkApplication` deployment.
+
+_Please note that these environment variable must be set in the operator's
+container, see [cluster.yaml](manifest/cluster.yaml) and
+[cluster-cm.yaml](manifest/cluster-cm.yaml) for operator deployment information._
+
 ### Related projects
 
 The radanalyticsio/spark-operator is not the only Kubernetes operator service

--- a/README.md
+++ b/README.md
@@ -124,16 +124,18 @@ The spark-operator contains several defaults that are implicit to the creation
 of Spark clusters and applications. Here are a list of environment variables
 that can be set to adjust the default behaviors of the operator.
 
-* `CRD` set to `true` if the operator the operator should respond to Custom
-  Resource Definitions, and set to `false` if it should respone to ConfigMaps.
+* `CRD` set to `true` if the operator should respond to Custom
+  Resources, and set to `false` if it should respone to ConfigMaps.
 * `DEFAULT_SPARK_CLUSTER_IMAGE` a container image reference that will be used
-  for all pods in a `SparkCluster` deployment.
-* `DEFAULT_SPARK_APP_IMAGE` a container image reference that will be used for
-  all executor pods in a `SparkApplication` deployment.
+  as a default for all pods in a `SparkCluster` deployment when the image is
+  not specified in the cluster manifest.
+* `DEFAULT_SPARK_APP_IMAGE` a container image reference that will be used as a
+  default for all executor pods in a `SparkApplication` deployment when the
+  image is not specified in the application manifest.
 
-_Please note that these environment variable must be set in the operator's
-container, see [cluster.yaml](manifest/cluster.yaml) and
-[cluster-cm.yaml](manifest/cluster-cm.yaml) for operator deployment information._
+_Please note that these environment variables must be set in the operator's
+container, see [operator.yaml](manifest/operator.yaml) and
+[operator-cm.yaml](manifest/operator-cm.yaml) for operator deployment information._
 
 ### Related projects
 

--- a/src/main/java/io/radanalytics/operator/Constants.java
+++ b/src/main/java/io/radanalytics/operator/Constants.java
@@ -3,6 +3,7 @@ package io.radanalytics.operator;
 public class Constants {
 
     public static String DEFAULT_SPARK_IMAGE = "quay.io/jkremser/openshift-spark:2.4.0";
+    public static String DEFAULT_SPARK_APP_IMAGE = "quay.io/jkremser/openshift-spark:2.3-latest";
     public static final String OPERATOR_TYPE_UI_LABEL = "ui";
     public static final String OPERATOR_TYPE_MASTER_LABEL = "master";
     public static final String OPERATOR_TYPE_WORKER_LABEL = "worker";
@@ -11,6 +12,14 @@ public class Constants {
         String ret = DEFAULT_SPARK_IMAGE;
         if (System.getenv("DEFAULT_SPARK_CLUSTER_IMAGE") != null) {
             ret = System.getenv("DEFAULT_SPARK_CLUSTER_IMAGE");
+        }
+        return ret;
+    }
+
+    public static String getDefaultSparkAppImage() { 
+        String ret = DEFAULT_SPARK_APP_IMAGE;
+        if (System.getenv("DEFAULT_SPARK_APP_IMAGE") != null) {
+            ret = System.getenv("DEFAULT_SPARK_APP_IMAGE");
         }
         return ret;
     }

--- a/src/main/resources/schema/sparkApplication.json
+++ b/src/main/resources/schema/sparkApplication.json
@@ -53,8 +53,7 @@
       "$ref": "#/definitions/ExecutorSpec"
     },
     "image": {
-      "type": "string",
-      "default": "quay.io/jkremser/openshift-spark:2.3-latest"
+      "type": "string"
     },
     "mainApplicationFile": {
       "type": "string"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
  
### Description

This change removes the default image set in the SparkApplication
schema and moves it to the constants definitions. It also adds a
function to detect the environment variable `SPARK_DEFAULT_APP_IMAGE` to
assist in overriding the default. Finally, the README is updated to
include instructions on configuring the operator.


#### Related Issue
<!-- if there is any -->

#186 

#### Types of changes
<!-- Use ONLY ONE that applies (and delete the rest) -->

 :sparkles: New feature (non-breaking change which adds functionality)
