### PR TITLE
Customize image

### DIFF
--- a/src/main/java/io/radanalytics/operator/app/KubernetesAppDeployer.java
+++ b/src/main/java/io/radanalytics/operator/app/KubernetesAppDeployer.java
@@ -46,7 +46,7 @@ public class KubernetesAppDeployer {
         }
 
         StringBuilder command = new StringBuilder();
-        command.append("/opt/spark/bin/spark-submit");
+        command.append("$SPARK_HOME/bin/spark-submit");
         if (app.getMainClass() != null) {
             command.append(" --class ").append(app.getMainClass());
         }

--- a/src/main/resources/schema/sparkCluster.json
+++ b/src/main/resources/schema/sparkCluster.json
@@ -106,10 +106,16 @@
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]"
         },
         "command": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "commandArgs": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/src/main/resources/schema/sparkCluster.json
+++ b/src/main/resources/schema/sparkCluster.json
@@ -104,6 +104,12 @@
           "existingJavaType" : "java.util.Map<String,String>",
           "type" : "string",
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]"
+        },
+        "command": {
+          "type": "string"
+        },
+        "commandArgs": {
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
  
### Description

in the issue

Now, one can override the default commands that will be executed for master and worker nodes, example:

```yaml
apiVersion: radanalytics.io/v1
kind: SparkCluster
metadata:
  name: my-spark-cluster
spec:
  worker:
    command:
    - /bin/sh
    - -c
    commandArgs:
    - sleep 500
```

#### Related Issue
issue #208 

#### Types of changes
<!-- Use ONLY ONE that applies (and delete the rest) -->

 :sparkles: New feature (non-breaking change which adds functionality)
