### PR TITLE
Schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <abstract-operator.version>0.6.4</abstract-operator.version>
+        <abstract-operator.version>0.6.5</abstract-operator.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/io/radanalytics/operator/app/KubernetesAppDeployer.java
+++ b/src/main/java/io/radanalytics/operator/app/KubernetesAppDeployer.java
@@ -2,8 +2,8 @@ package io.radanalytics.operator.app;
 
 import io.fabric8.kubernetes.api.model.*;
 import io.radanalytics.types.Deps;
-import io.radanalytics.types.DriverSpec;
-import io.radanalytics.types.ExecutorSpec;
+import io.radanalytics.types.Executor;
+import io.radanalytics.types.Driver;
 import io.radanalytics.types.SparkApplication;
 
 import java.util.*;
@@ -37,8 +37,8 @@ public class KubernetesAppDeployer {
         envVars.add(env("APPLICATION_NAME", name));
         app.getEnv().forEach(kv -> envVars.add(env(kv.getName(), kv.getValue())));
 
-        final DriverSpec driver = Optional.ofNullable(app.getDriver()).orElse(new DriverSpec());
-        final ExecutorSpec executor = Optional.ofNullable(app.getExecutor()).orElse(new ExecutorSpec());
+        final Driver driver = Optional.ofNullable(app.getDriver()).orElse(new Driver());
+        final Executor executor = Optional.ofNullable(app.getExecutor()).orElse(new Executor());
  
         String imageRef = getDefaultSparkAppImage(); // from Constants
         if (app.getImage() != null) {

--- a/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
+++ b/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
@@ -147,7 +147,7 @@ public class InitContainersHelper {
     }
 
     private static Container createConfigOverrideContainer(SparkCluster cluster, PodSpec podSpec, boolean cmExists) {
-        final List<io.radanalytics.types.NameValue> config = cluster.getSparkConfiguration();
+        final List<io.radanalytics.types.SparkConfiguration> config = cluster.getSparkConfiguration();
         String cmMountName = "configmap-dir";
         String cmMountPath = "/tmp/config/fromCM";
         List<VolumeMount> mounts = new ArrayList<>(2);
@@ -216,9 +216,9 @@ public class InitContainersHelper {
     }
 
     private static String getSparkHome(SparkCluster cluster) {
-        Predicate<NameValue> p = nv -> "SPARK_HOME".equals(nv.getName());
+        Predicate<Env> p = nv -> "SPARK_HOME".equals(nv.getName());
         if (!cluster.getEnv().isEmpty() && cluster.getEnv().stream().anyMatch(p)) {
-            Optional<NameValue> sparkHome = cluster.getEnv().stream().filter(p).findFirst();
+            Optional<Env> sparkHome = cluster.getEnv().stream().filter(p).findFirst();
             if (sparkHome.isPresent() && null != sparkHome.get().getValue() && !sparkHome.get().getValue().trim().isEmpty()) {
                 return sparkHome.get().getValue();
             }

--- a/src/main/java/io/radanalytics/operator/cluster/RunningClusters.java
+++ b/src/main/java/io/radanalytics/operator/cluster/RunningClusters.java
@@ -1,17 +1,13 @@
 package io.radanalytics.operator.cluster;
 
-import io.prometheus.client.log4j.InstrumentedAppender;
-import io.radanalytics.types.RCSpec;
 import io.radanalytics.types.SparkCluster;
-import org.apache.log4j.Logger;
+import io.radanalytics.types.Worker;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import static io.radanalytics.operator.cluster.MetricsHelper.runningClusters;
-import static io.radanalytics.operator.cluster.MetricsHelper.startedTotal;
-import static io.radanalytics.operator.cluster.MetricsHelper.workers;
+import static io.radanalytics.operator.cluster.MetricsHelper.*;
 
 
 
@@ -29,7 +25,7 @@ public class RunningClusters {
     public void put(SparkCluster ci) {
         runningClusters.labels(namespace).inc();
         startedTotal.labels(namespace).inc();
-        workers.labels(ci.getName(), namespace).set(Optional.ofNullable(ci.getWorker()).orElse(new RCSpec()).getInstances());
+        workers.labels(ci.getName(), namespace).set(Optional.ofNullable(ci.getWorker()).orElse(new Worker()).getInstances());
         clusters.put(ci.getName(), ci);
     }
 

--- a/src/main/java/io/radanalytics/operator/cluster/SparkClusterOperator.java
+++ b/src/main/java/io/radanalytics/operator/cluster/SparkClusterOperator.java
@@ -12,11 +12,11 @@ import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListMultiDeletable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
+import io.radanalytics.operator.Constants;
 import io.radanalytics.operator.common.AbstractOperator;
 import io.radanalytics.operator.common.Operator;
-import io.radanalytics.operator.Constants;
-import io.radanalytics.types.RCSpec;
 import io.radanalytics.types.SparkCluster;
+import io.radanalytics.types.Worker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +62,7 @@ public class SparkClusterOperator extends AbstractOperator<SparkCluster> {
     @Override
     protected void onModify(SparkCluster newCluster) {
         String name = newCluster.getName();
-        int newWorkers = Optional.ofNullable(newCluster.getWorker()).orElse(new RCSpec()).getInstances();
+        int newWorkers = Optional.ofNullable(newCluster.getWorker()).orElse(new Worker()).getInstances();
 
         SparkCluster existingCluster = getClusters().getCluster(name);
         if (null == existingCluster) {
@@ -131,7 +131,7 @@ public class SparkClusterOperator extends AbstractOperator<SparkCluster> {
 
         // scale
         desiredSet.forEach(dCluster -> {
-            int desiredWorkers = Optional.ofNullable(dCluster.getWorker()).orElse(new RCSpec()).getInstances();
+            int desiredWorkers = Optional.ofNullable(dCluster.getWorker()).orElse(new Worker()).getInstances();
             Integer actualWorkers = actual.get(dCluster.getName());
             if (actualWorkers != null && desiredWorkers != actualWorkers) {
                 change.set(true);
@@ -203,7 +203,7 @@ public class SparkClusterOperator extends AbstractOperator<SparkCluster> {
      */
     private boolean isOnlyScale(SparkCluster oldC, SparkCluster newC) {
         boolean retVal = oldC.getWorker().getInstances() != newC.getWorker().getInstances();
-        int backup = Optional.ofNullable(newC.getWorker()).orElse(new RCSpec()).getInstances();
+        int backup = Optional.ofNullable(newC.getWorker()).orElse(new Worker()).getInstances();
         newC.getWorker().setInstances(oldC.getWorker().getInstances());
         retVal &= oldC.equals(newC);
         newC.getWorker().setInstances(backup);

--- a/src/main/resources/schema/sparkApplication.json
+++ b/src/main/resources/schema/sparkApplication.json
@@ -214,8 +214,5 @@
     "sparkConfigMap": {
       "type": "string"
     }
-  },
-  "required": [
-    "mainApplicationFile"
-  ]
+  }
 }

--- a/src/main/resources/schema/sparkApplication.json
+++ b/src/main/resources/schema/sparkApplication.json
@@ -50,94 +50,23 @@
       "type": "string"
     },
     "driver": {
-      "$ref": "#/definitions/DriverSpec"
-    },
-    "executor": {
-      "$ref": "#/definitions/ExecutorSpec"
-    },
-    "image": {
-      "type": "string"
-    },
-    "mainApplicationFile": {
-      "type": "string"
-    },
-    "mainClass": {
-      "type": "string"
-    },
-    "arguments": {
-      "type": "string"
-    },
-    "mode": {
-      "type": "string",
-      "default": "cluster",
-      "enum": ["client", "cluster"],
-      "javaEnumNames" : ["client","cluster"]
-    },
-    "restartPolicy": {
-      "type": "string",
-      "default": "Always",
-      "enum": ["Always", "OnFailure", "Never"],
-      "javaEnumNames" : ["Always","OnFailure", "Never"]
-    },
-    "imagePullPolicy": {
-      "type": "string",
-      "default": "IfNotPresent",
-      "enum": ["IfNotPresent", "Always", "Never"],
-      "javaEnumNames" : ["IfNotPresent","Always", "Never"]
-    },
-    "type": {
-      "type": "string",
-      "default": "Java",
-      "enum": ["Java", "Scala", "Python", "R"],
-      "javaEnumNames" : ["Java","Scala", "Python", "R"]
-    },
-    "sleep": {
-      "type": "integer",
-      "default": "31536000",
-      "minimum": "0"
-    },
-    "labels": {
-      "$ref": "#/definitions/Labels"
-    },
-    "env": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": { "type": "string" },
-          "value": { "type": "string" }
-        },
-        "required": ["name", "value"]
-      }
-    },
-    "sparkConfigMap": {"type": "string"}
-  },
-  "required": [ "mainApplicationFile" ],
-  "definitions": {
-    "CommonNodeSpec": {
       "type": "object",
-      "javaType": "io.radanalytics.types.CommonNodeSpec",
       "properties": {
         "memory": {
           "type": "string",
           "default": "512m"
         },
-        "memoryOverhead": { "type": "string" },
+        "memoryOverhead": {
+          "type": "string"
+        },
         "image": {
-          "type": "string",
-          "default": "#/properties/image/default"
+          "type": "string"
         },
         "labels": {
-          "$ref": "#/definitions/Labels"
-        }
-      }
-    },
-    "DriverSpec": {
-      "type": "object",
-      "extends": {
-        "$ref": "#/definitions/CommonNodeSpec"
-      },
-      "properties": {
+          "type": "string",
+          "existingJavaType": "java.util.Map<String,String>",
+          "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]"
+        },
         "cores": {
           "type": "string",
           "default": "0.5"
@@ -152,12 +81,24 @@
         }
       }
     },
-    "ExecutorSpec": {
+    "executor": {
       "type": "object",
-      "extends": {
-        "$ref": "#/definitions/CommonNodeSpec"
-      },
       "properties": {
+        "memory": {
+          "type": "string",
+          "default": "512m"
+        },
+        "memoryOverhead": {
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "string",
+          "existingJavaType": "java.util.Map<String,String>",
+          "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]"
+        },
         "instances": {
           "type": "integer",
           "default": "1",
@@ -174,10 +115,107 @@
         }
       }
     },
-    "Labels": {
+    "image": {
+      "type": "string"
+    },
+    "mainApplicationFile": {
+      "type": "string"
+    },
+    "mainClass": {
+      "type": "string"
+    },
+    "arguments": {
+      "type": "string"
+    },
+    "mode": {
       "type": "string",
-      "existingJavaType" : "java.util.Map<String,String>",
+      "default": "cluster",
+      "enum": [
+        "client",
+        "cluster"
+      ],
+      "javaEnumNames": [
+        "client",
+        "cluster"
+      ]
+    },
+    "restartPolicy": {
+      "type": "string",
+      "default": "Always",
+      "enum": [
+        "Always",
+        "OnFailure",
+        "Never"
+      ],
+      "javaEnumNames": [
+        "Always",
+        "OnFailure",
+        "Never"
+      ]
+    },
+    "imagePullPolicy": {
+      "type": "string",
+      "default": "IfNotPresent",
+      "enum": [
+        "IfNotPresent",
+        "Always",
+        "Never"
+      ],
+      "javaEnumNames": [
+        "IfNotPresent",
+        "Always",
+        "Never"
+      ]
+    },
+    "type": {
+      "type": "string",
+      "default": "Java",
+      "enum": [
+        "Java",
+        "Scala",
+        "Python",
+        "R"
+      ],
+      "javaEnumNames": [
+        "Java",
+        "Scala",
+        "Python",
+        "R"
+      ]
+    },
+    "sleep": {
+      "type": "integer",
+      "default": "31536000",
+      "minimum": "0"
+    },
+    "labels": {
+      "type": "string",
+      "existingJavaType": "java.util.Map<String,String>",
       "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]"
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "value"
+        ]
+      }
+    },
+    "sparkConfigMap": {
+      "type": "string"
     }
-  }
+  },
+  "required": [
+    "mainApplicationFile"
+  ]
 }

--- a/src/main/resources/schema/sparkCluster.json
+++ b/src/main/resources/schema/sparkCluster.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "A Spark cluster configuration",
+  "dependencies": null,
   "type": "object",
   "extends": {
     "type": "object",
@@ -8,10 +9,70 @@
   },
   "properties": {
     "master": {
-      "$ref": "#/definitions/RCSpec"
+      "type": "object",
+      "properties": {
+        "instances": {
+          "type": "integer",
+          "default": "1",
+          "minimum": "1"
+        },
+        "memory": {
+          "type": "string"
+        },
+        "cpu": {
+          "type": "string"
+        },
+        "labels": {
+          "existingJavaType": "java.util.Map<String,String>",
+          "type": "string",
+          "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]"
+        },
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "commandArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "worker": {
-      "$ref": "#/definitions/RCSpec"
+      "type": "object",
+      "properties": {
+        "instances": {
+          "type": "integer",
+          "default": "1",
+          "minimum": "0"
+        },
+        "memory": {
+          "type": "string"
+        },
+        "cpu": {
+          "type": "string"
+        },
+        "labels": {
+          "existingJavaType": "java.util.Map<String,String>",
+          "type": "string",
+          "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]"
+        },
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "commandArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "customImage": {
       "type": "string"
@@ -28,12 +89,31 @@
       "type": "string"
     },
     "env": {
-      "$ref": "#/definitions/NameValue"
+      "type": "array",
+      "items": {
+        "type": "object",
+        "javaType": "io.radanalytics.types.Env",
+        "properties": {
+          "name": { "type": "string" },
+          "value": { "type": "string" }
+        },
+        "required": ["name", "value"]
+      }
     },
-    "sparkConfiguration": { "$ref": "#/definitions/NameValue" },
-    "labels" : {
-      "existingJavaType" : "java.util.Map<String,String>",
-      "type" : "object"
+    "sparkConfiguration": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "value": { "type": "string" }
+        },
+        "required": ["name", "value"]
+      }
+    },
+    "labels": {
+      "type": "object",
+      "existingJavaType": "java.util.Map<String,String>"
     },
     "historyServer": {
       "type": "object",
@@ -44,9 +124,16 @@
         "type": {
           "type": "string",
           "default": "sharedVolume",
-          "enum": ["sharedVolume", "remoteStorage"],
-          "javaEnumNames" : ["sharedVolume","remoteStorage"]
+          "enum": [
+            "sharedVolume",
+            "remoteStorage"
+          ],
+          "javaEnumNames": [
+            "sharedVolume",
+            "remoteStorage"
+          ]
         },
+
         "sharedVolume": {
           "type": "object",
           "properties": {
@@ -75,60 +162,19 @@
       "items": {
         "type": "object",
         "properties": {
-          "url": { "type": "string" },
-          "to": { "type": "string" },
-          "required": { "type": "boolean", "default": "false" },
-          "downloadTimeout": { "type": "integer", "minimum": "0" }
+          "url": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          }
         },
-        "required": ["url", "to"]
+        "required": [
+          "url",
+          "to"
+        ]
       }
     }
   },
-  "required": [ ],
-  "definitions": {
-    "RCSpec": {
-      "type": "object",
-      "properties": {
-        "instances": {
-          "type": "integer",
-          "default": "1",
-          "minimum": "0"
-        },
-        "memory": {
-          "type": "string"
-        },
-        "cpu": {
-          "type": "string"
-        },
-        "labels" : {
-          "existingJavaType" : "java.util.Map<String,String>",
-          "type" : "string",
-          "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]"
-        },
-        "command": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "commandArgs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "NameValue": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": { "type": "string" },
-          "value": { "type": "string" }
-        },
-        "required": ["name", "value"]
-      }
-    }
-  }
+  "required": []
 }

--- a/src/main/resources/schema/sparkHistoryServer.json
+++ b/src/main/resources/schema/sparkHistoryServer.json
@@ -15,6 +15,7 @@
     },
     "sharedVolume": {
       "type": "object",
+      "existingJavaType": "io.radanalytics.types.SharedVolume",
       "properties": {
         "size": {
           "type": "string",
@@ -34,6 +35,7 @@
       "type": "array",
       "items": {
         "type": "object",
+        "existingJavaType": "io.radanalytics.types.SparkConfiguration",
         "properties": {
           "name": { "type": "string" },
           "value": { "type": "string" }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
  
### Description
This also required the change in the abstract-operator: https://github.com/jvm-operators/abstract-operator/commit/d8cef499524e0b8f2352acec14d831a3f46b2301

To be able to create the `openAPIV3Schema` element within CRD definion, the schema can't contain:
* definitions
* dependencies
* $refs
* default values

Luckily, we didn't have any `dependencies` declared in the schema before so no need to change here. `definitions` and `$ref`s are quite dual to each other so this is actually the biggest portion of what this PR does, e.g. unwrapping (/dereferencing) the definition section and duplicating it over and over in the schema => not very DRY, hopefully K8s will support the definitions and $ref one day.

As for the default values, this was done [here](https://github.com/jvm-operators/abstract-operator/commit/d8cef499524e0b8f2352acec14d831a3f46b2301#diff-52f03e99289fcf30d039920b62bd1301R93) in the abstract-operator. I recursively scan the schema and remove all the default values before sending it to K8s api server.

#### Related Issue
issue #217 

#### Types of changes
<!-- Use ONLY ONE that applies (and delete the rest) -->

 :bug: Bug fix (non-breaking change which fixes an issue)



example output:
<details><summary><code>λ oc get crds -o yaml | grep -A25 openAPIV3Schema</code></summary>

```yaml
      openAPIV3Schema:
        $schema: http://json-schema.org/draft-07/schema#
        description: A Spark application configuration
        properties:
          arguments:
            type: string
          deps:
            properties:
              downloadTimeout:
                minimum: 0
                type: integer
              files:
                items:
                  type: string
                type: array
              filesDownloadDir:
                type: string
              jars:
                items:
                  type: string
                type: array
              jarsDownloadDir:
                type: string
              maxSimultaneousDownloads:
                minimum: 0
                type: integer
--
      openAPIV3Schema:
        $schema: http://json-schema.org/draft-07/schema#
        description: A Spark cluster configuration
        properties:
          customImage:
            type: string
          downloadData:
            items:
              properties:
                to:
                  type: string
                url:
                  type: string
              required:
              - url
              - to
              type: object
            type: array
          env:
            items:
              properties:
                name:
                  type: string
                value:
                  type: string
              required:
--
      openAPIV3Schema:
        $schema: http://json-schema.org/draft-07/schema#
        description: A Spark history server configuration
        properties:
          cleaner:
            properties:
              enabled:
                description: Specifies whether the History Server should periodically
                  clean up event logs from storage.
                type: boolean
              interval:
                description: How often (days) the filesystem job history cleaner checks
                  for files to delete. Files are only deleted if they are older than
                  spark.history.fs.cleaner.maxAge
                minimum: 1
                type: integer
              maxAge:
                description: '# of days, job history files older than this will be
                  deleted when the filesystem history cleaner runs.'
                minimum: 1
                type: integer
            type: object
          customImage:
            description: Container image that will be used for the spark history server.
              It assumes the standard Spark distribution under /opt/spark
            type: string

```
</details>