### PR TITLE
Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,16 @@ services:
 install: true
 
 before_cache:
-  # Save tagged docker images
-  - >
-    mkdir -p $HOME/docker && docker images -a --filter='dangling=false' --format '{{.Repository}}:{{.Tag}} {{.ID}}'
-    | xargs -n 2 -t sh -c 'test -e $HOME/docker/$1.tar.gz || docker save $0 | gzip -2 > $HOME/docker/$1.tar.gz'
+  - ./.travis/cache/.travis.before_cache.sh
 
 before_install:
-  # Load cached docker images
-  - if [[ -d $HOME/docker ]]; then ls $HOME/docker/*.tar.gz | xargs -I {file} sh -c "zcat {file} | docker load"; fi
+  - ./.travis/cache/.travis.before_install.sh
+
 
 cache:
-  timeout: 600
+  timeout: 120
   directories:
-  - $HOME/.m2
+  - $HOME/maven
   - $HOME/docker
 
 stages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,6 @@ jobs:
       name: "Maven & cont. image build"
       language: java
       script:
-        # Pull docker images that will be cached
-        - docker pull quay.io/jkremser/openshift-spark:2.4.0
-        - docker pull quay.io/jkremser/openshift-spark:2.3-latest
         # run the tests
         - make build-travis test
 

--- a/.travis/cache/.travis.before_cache.sh
+++ b/.travis/cache/.travis.before_cache.sh
@@ -2,6 +2,8 @@
 
 set -x
 
+DIR="${DIR:-$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )}"
+
 main() {
   docker_cache
   maven_cache
@@ -13,9 +15,9 @@ docker_cache(){
     exit 0
   else
     if [[ "$BIN" = "oc" ]]; then
-      specific=container-images-oc.txt
+      specific="${DIR}/container-images-oc.txt"
     elif [[ "$BIN" = "kubectl" ]]; then
-      specific=container-images-k8s.txt
+      specific="${DIR}/container-images-k8s.txt"
     else
       echo "Unknown or empty \$BIN variable, skipping before-cache script.."
       exit 1
@@ -24,7 +26,7 @@ docker_cache(){
 
   mkdir -p $HOME/docker
   docker images -a --filter='dangling=false' --format '{{.Repository}}:{{.Tag}} {{.ID}}' > $HOME/docker/${BIN}-list.txt
-  cat container-images-common.txt ${specific} | while read c
+  cat "${DIR}/container-images-common.txt ${specific}" | while read c
   do
     cat $HOME/docker/${BIN}-list.txt | grep "$c" | xargs -n 2 -t sh -c 'test -e $HOME/docker/$1.tar.gz || docker save $0 | gzip -2 > $HOME/docker/$1.tar.gz'
   done

--- a/.travis/cache/.travis.before_cache.sh
+++ b/.travis/cache/.travis.before_cache.sh
@@ -11,15 +11,15 @@ docker_cache(){
   if [[ "$TRAVIS_JOB_NUMBER" == *.1 ]] || [[ "$TRAVIS_JOB_NUMBER" == *.10 ]]; then
     echo "Skipping docker cache for .1 and .10 jobs"
     exit 0
-  fi
-
-  if [[ "$BIN" = "oc" ]]; then
-    specific=container-images-oc.txt
-  elif [[ "$BIN" = "kubectl" ]]; then
-    specific=container-images-k8s.txt
   else
-    echo "Unknown or empty \$BIN variable, skipping before-cache script.."
-    exit 1
+    if [[ "$BIN" = "oc" ]]; then
+      specific=container-images-oc.txt
+    elif [[ "$BIN" = "kubectl" ]]; then
+      specific=container-images-k8s.txt
+    else
+      echo "Unknown or empty \$BIN variable, skipping before-cache script.."
+      exit 1
+    fi
   fi
 
   mkdir -p $HOME/docker

--- a/.travis/cache/.travis.before_cache.sh
+++ b/.travis/cache/.travis.before_cache.sh
@@ -8,6 +8,11 @@ main() {
 }
 
 docker_cache(){
+  if [[ "$TRAVIS_JOB_NUMBER" == *.1 ]] || [[ "$TRAVIS_JOB_NUMBER" == *.10 ]]; then
+    echo "Skipping docker cache for .1 and .10 jobs"
+    exit 0
+  fi
+
   if [[ "$BIN" = "oc" ]]; then
     specific=container-images-oc.txt
   elif [[ "$BIN" = "kubectl" ]]; then
@@ -18,10 +23,10 @@ docker_cache(){
   fi
 
   mkdir -p $HOME/docker
-  docker images -a --filter='dangling=false' --format '{{.Repository}}:{{.Tag}} {{.ID}}' > $HOME/docker/list.txt
+  docker images -a --filter='dangling=false' --format '{{.Repository}}:{{.Tag}} {{.ID}}' > $HOME/docker/${BIN}-list.txt
   cat container-images-common.txt ${specific} | while read c
   do
-    cat $HOME/docker/list.txt | grep "$c" | xargs -n 2 -t sh -c 'test -e $HOME/docker/$1.tar.gz || docker save $0 | gzip -2 > $HOME/docker/$1.tar.gz'
+    cat $HOME/docker/${BIN}-list.txt | grep "$c" | xargs -n 2 -t sh -c 'test -e $HOME/docker/$1.tar.gz || docker save $0 | gzip -2 > $HOME/docker/$1.tar.gz'
   done
 }
 

--- a/.travis/cache/.travis.before_cache.sh
+++ b/.travis/cache/.travis.before_cache.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -x
+
+main() {
+  docker_cache
+  maven_cache
+}
+
+docker_cache(){
+  if [[ "$BIN" = "oc" ]]; then
+    specific=container-images-oc.txt
+  elif [[ "$BIN" = "kubectl" ]]; then
+    specific=container-images-k8s.txt
+  else
+    echo "Unknown or empty \$BIN variable, skipping before-cache script.."
+    exit 1
+  fi
+
+  mkdir -p $HOME/docker
+  docker images -a --filter='dangling=false' --format '{{.Repository}}:{{.Tag}} {{.ID}}' > $HOME/docker/list.txt
+  cat container-images-common.txt ${specific} | while read c
+  do
+    cat $HOME/docker/list.txt | grep "$c" | xargs -n 2 -t sh -c 'test -e $HOME/docker/$1.tar.gz || docker save $0 | gzip -2 > $HOME/docker/$1.tar.gz'
+  done
+}
+
+maven_cache(){
+  mkdir -p $HOME/maven
+  cd $HOME/.m2/repository
+  tar cf - --exclude=io/radanalytics . | (cd $HOME/maven && tar xf - )
+}
+
+main

--- a/.travis/cache/.travis.before_install.sh
+++ b/.travis/cache/.travis.before_install.sh
@@ -27,6 +27,9 @@ docker_cache(){
     cat ${images} | while read c
     do
       cat $HOME/docker/${BIN:-oc}-list.txt | grep "$c" | xargs -n 2 sh -c 'test -e $HOME/docker/$1.tar.gz && (zcat $HOME/docker/$1.tar.gz | docker load) || true'
+
+      # make sure it's there, this should be a cheap operation if the previous command was successful
+      docker pull ${c}
     done
   fi
 }

--- a/.travis/cache/.travis.before_install.sh
+++ b/.travis/cache/.travis.before_install.sh
@@ -2,11 +2,12 @@
 
 set -x
 
+DIR="${DIR:-$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )}"
+
 main() {
   docker_cache
   maven_cache
 }
-
 
 docker_cache(){
   if [[ "$TRAVIS_JOB_NUMBER" == *.1 ]] || [[ "$TRAVIS_JOB_NUMBER" == *.10 ]]; then
@@ -22,10 +23,10 @@ docker_cache(){
     fi
   fi
 
-  if [[ -d $HOME/docker ]] && [[ -e $HOME/docker/${BIN}-list.txt ]]; then
+  if [[ -d $HOME/docker ]] && [[ -e $HOME/docker/${BIN:-oc}-list.txt ]]; then
     cat ${images} | while read c
     do
-      cat $HOME/docker/${BIN}-list.txt | grep "$c" | xargs -n 2 sh -c 'test -e $HOME/docker/$1.tar.gz && (zcat $HOME/docker/$1.tar.gz | docker load) || true'
+      cat $HOME/docker/${BIN:-oc}-list.txt | grep "$c" | xargs -n 2 sh -c 'test -e $HOME/docker/$1.tar.gz && (zcat $HOME/docker/$1.tar.gz | docker load) || true'
     done
   fi
 }

--- a/.travis/cache/.travis.before_install.sh
+++ b/.travis/cache/.travis.before_install.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -x
+
+main() {
+  docker_cache
+  maven_cache
+}
+
+
+docker_cache(){
+  if [[ "$BIN" = "oc" ]]; then
+    specific=container-images-oc.txt
+  elif [[ "$BIN" = "kubectl" ]]; then
+    specific=container-images-k8s.txt
+  else
+    echo "Unknown or empty \$BIN variable, skipping before-cache script.."
+    exit 1
+  fi
+
+  if [[ -d $HOME/docker ]] && [[ -e $HOME/docker/list.txt ]]; then
+    cat container-images-common.txt ${specific} | while read c
+    do
+      cat $HOME/docker/list.txt | grep "$c" | xargs -n 2 sh -c 'test -e $HOME/docker/$1.tar.gz && (zcat $HOME/docker/$1.tar.gz | docker load) || true'
+    done
+  fi
+}
+
+maven_cache(){
+  cp -r $HOME/.m2/repository $HOME/.m2/repository/
+}
+
+main

--- a/.travis/cache/.travis.before_install.sh
+++ b/.travis/cache/.travis.before_install.sh
@@ -10,12 +10,12 @@ main() {
 
 docker_cache(){
   if [[ "$TRAVIS_JOB_NUMBER" == *.1 ]] || [[ "$TRAVIS_JOB_NUMBER" == *.10 ]]; then
-    images="container-images-common.txt"
+    images="${DIR}/container-images-common.txt"
   else
     if [[ "$BIN" = "oc" ]]; then
-      images="container-images-common.txt container-images-oc.txt"
+      images="${DIR}/container-images-common.txt ${DIR}/container-images-oc.txt"
     elif [[ "$BIN" = "kubectl" ]]; then
-      images="container-images-common.txt container-images-k8s.txt"
+      images="${DIR}/container-images-common.txt ${DIR}/container-images-k8s.txt"
     else
       echo "Unknown or empty \$BIN variable, skipping before-cache script.."
       exit 1
@@ -25,7 +25,7 @@ docker_cache(){
   if [[ -d $HOME/docker ]] && [[ -e $HOME/docker/${BIN}-list.txt ]]; then
     cat ${images} | while read c
     do
-      cat ${BIN}-$HOME/docker/list.txt | grep "$c" | xargs -n 2 sh -c 'test -e $HOME/docker/$1.tar.gz && (zcat $HOME/docker/$1.tar.gz | docker load) || true'
+      cat $HOME/docker/${BIN}-list.txt | grep "$c" | xargs -n 2 sh -c 'test -e $HOME/docker/$1.tar.gz && (zcat $HOME/docker/$1.tar.gz | docker load) || true'
     done
   fi
 }

--- a/.travis/cache/.travis.before_install.sh
+++ b/.travis/cache/.travis.before_install.sh
@@ -18,10 +18,16 @@ docker_cache(){
     exit 1
   fi
 
-  if [[ -d $HOME/docker ]] && [[ -e $HOME/docker/list.txt ]]; then
-    cat container-images-common.txt ${specific} | while read c
+  if [[ "$TRAVIS_JOB_NUMBER" == *.1 ]] || [[ "$TRAVIS_JOB_NUMBER" == *.10 ]]; then
+    images="container-images-common.txt"
+  else
+    images="container-images-common.txt ${specific}"
+  fi
+
+  if [[ -d $HOME/docker ]] && [[ -e $HOME/docker/${BIN}-list.txt ]]; then
+    cat ${images} | while read c
     do
-      cat $HOME/docker/list.txt | grep "$c" | xargs -n 2 sh -c 'test -e $HOME/docker/$1.tar.gz && (zcat $HOME/docker/$1.tar.gz | docker load) || true'
+      cat ${BIN}-$HOME/docker/list.txt | grep "$c" | xargs -n 2 sh -c 'test -e $HOME/docker/$1.tar.gz && (zcat $HOME/docker/$1.tar.gz | docker load) || true'
     done
   fi
 }

--- a/.travis/cache/.travis.before_install.sh
+++ b/.travis/cache/.travis.before_install.sh
@@ -9,19 +9,17 @@ main() {
 
 
 docker_cache(){
-  if [[ "$BIN" = "oc" ]]; then
-    specific=container-images-oc.txt
-  elif [[ "$BIN" = "kubectl" ]]; then
-    specific=container-images-k8s.txt
-  else
-    echo "Unknown or empty \$BIN variable, skipping before-cache script.."
-    exit 1
-  fi
-
   if [[ "$TRAVIS_JOB_NUMBER" == *.1 ]] || [[ "$TRAVIS_JOB_NUMBER" == *.10 ]]; then
     images="container-images-common.txt"
   else
-    images="container-images-common.txt ${specific}"
+    if [[ "$BIN" = "oc" ]]; then
+      images="container-images-common.txt container-images-oc.txt"
+    elif [[ "$BIN" = "kubectl" ]]; then
+      images="container-images-common.txt container-images-k8s.txt"
+    else
+      echo "Unknown or empty \$BIN variable, skipping before-cache script.."
+      exit 1
+    fi
   fi
 
   if [[ -d $HOME/docker ]] && [[ -e $HOME/docker/${BIN}-list.txt ]]; then
@@ -33,7 +31,8 @@ docker_cache(){
 }
 
 maven_cache(){
-  cp -r $HOME/.m2/repository $HOME/.m2/repository/
+  mkdir -p $HOME/.m2/repository/
+  cp -r $HOME/maven $HOME/.m2/repository/
 }
 
 main

--- a/.travis/cache/container-images-common.txt
+++ b/.travis/cache/container-images-common.txt
@@ -1,0 +1,5 @@
+jkremser/mini-jre:8.1
+fabric8/java-centos-openjdk8-jdk:1.5.1
+quay.io/jkremser/openshift-spark:2.3-latest
+quay.io/jkremser/openshift-spark:2.4.0
+busybox:latest

--- a/.travis/cache/container-images-common.txt
+++ b/.travis/cache/container-images-common.txt
@@ -2,4 +2,5 @@ jkremser/mini-jre:8.1
 fabric8/java-centos-openjdk8-jdk:1.5.1
 quay.io/jkremser/openshift-spark:2.3-latest
 quay.io/jkremser/openshift-spark:2.4.0
+jkremser/spark-operator:2.4.0-ntlk
 busybox:latest

--- a/.travis/cache/container-images-k8s.txt
+++ b/.travis/cache/container-images-k8s.txt
@@ -1,0 +1,7 @@
+k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.1
+gcr.io/google-containers/kube-addon-manager:v6.5
+gcr.io/k8s-minikube/storage-provisioner:v1.8.0
+k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.5
+k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.5
+k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.5
+k8s.gcr.io/pause-amd64:3.0

--- a/.travis/cache/container-images-oc.txt
+++ b/.travis/cache/container-images-oc.txt
@@ -1,0 +1,6 @@
+openshift/origin-web-console:v3.9.0
+openshift/origin-docker-registry:v3.9.0
+openshift/origin-haproxy-router:v3.9.0
+openshift/origin-deployer:v3.9.0
+openshift/origin:v3.9.0
+openshift/origin-pod:v3.9.0


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
  
### Description
Using custom bash script that handle the save to and load from cache better than the one-liners previously specified in the `.travis.yml`

Especially the docker load operation is expensive, so for openshift stage it only loads those image that are specified on the white list for oc build. Similarly for the k8s stage. Previously, the cache mechanism was detecting the changes in the `~/.m2/repository`, therefore we now store the cache in `~/maven` and copy the content to and from the `~/.m2/repository`.

#### Related Issue
Fixes issue #221 


#### Types of changes
<!-- Use ONLY ONE that applies (and delete the rest) -->

 :bulb: Updated docs / Refactor code / Added a tests case / Automation (non-breaking change)
