### PR TITLE
Simple way to download maven artifact and use them for spark master and workers

### DIFF
--- a/.travis/.travis.test-common.sh
+++ b/.travis/.travis.test-common.sh
@@ -169,15 +169,15 @@ testFullConfigCluster() {
   os::cmd::try_until_text "${BIN} get pod -l radanalytics.io/deployment=sparky-cluster-w -o yaml" 'ready: true' && \
   os::cmd::try_until_text "${BIN} get pod -l radanalytics.io/deployment=sparky-cluster-m -o yaml" 'ready: true' && \
   os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/SparkCluster=sparky-cluster | wc -l" '3' && \
-  sleep 30 && \
+  sleep 150 && \
   local worker_pod=`${BIN} get pod -l radanalytics.io/deployment=sparky-cluster-w -o='jsonpath="{.items[0].metadata.name}"' | sed 's/"//g'` && \
   os::cmd::expect_success_and_text "${BIN} exec $worker_pod ls" 'README.md' && \
   os::cmd::expect_success_and_text "${BIN} exec $worker_pod env" 'FOO=bar' && \
   os::cmd::expect_success_and_text "${BIN} exec $worker_pod env" 'SPARK_WORKER_CORES=2' && \
   os::cmd::expect_success_and_text "${BIN} exec $worker_pod cat /opt/spark/conf/spark-defaults.conf" 'spark.history.retainedApplications 100' && \
   os::cmd::expect_success_and_text "${BIN} exec $worker_pod cat /opt/spark/conf/spark-defaults.conf" 'autoBroadcastJoinThreshold 20971520' && \
-  os::cmd::expect_success_and_text "${BIN} exec $worker_pod -- ls /tmp/jars | grep aws" 'com.amazonaws_aws-java-sdk-' && \
-  os::cmd::expect_success_and_text "${BIN} exec $worker_pod -- ls /tmp/jars | grep aws" 'org.apache.hadoop_hadoop-aws-' && \
+  os::cmd::try_until_text "${BIN} exec $worker_pod -- ls /tmp/jars | grep aws" 'com.amazonaws_aws-java-sdk-' && \
+  os::cmd::try_until_text "${BIN} exec $worker_pod -- ls /tmp/jars | grep aws" 'org.apache.hadoop_hadoop-aws-' && \
   os::cmd::expect_success_and_text '${BIN} delete sparkcluster sparky-cluster' '"?sparky-cluster"? deleted'
 }
 

--- a/.travis/.travis.test-common.sh
+++ b/.travis/.travis.test-common.sh
@@ -169,13 +169,15 @@ testFullConfigCluster() {
   os::cmd::try_until_text "${BIN} get pod -l radanalytics.io/deployment=sparky-cluster-w -o yaml" 'ready: true' && \
   os::cmd::try_until_text "${BIN} get pod -l radanalytics.io/deployment=sparky-cluster-m -o yaml" 'ready: true' && \
   os::cmd::try_until_text "${BIN} get pods --no-headers -l radanalytics.io/SparkCluster=sparky-cluster | wc -l" '3' && \
-  sleep 10 && \
+  sleep 30 && \
   local worker_pod=`${BIN} get pod -l radanalytics.io/deployment=sparky-cluster-w -o='jsonpath="{.items[0].metadata.name}"' | sed 's/"//g'` && \
   os::cmd::expect_success_and_text "${BIN} exec $worker_pod ls" 'README.md' && \
   os::cmd::expect_success_and_text "${BIN} exec $worker_pod env" 'FOO=bar' && \
   os::cmd::expect_success_and_text "${BIN} exec $worker_pod env" 'SPARK_WORKER_CORES=2' && \
   os::cmd::expect_success_and_text "${BIN} exec $worker_pod cat /opt/spark/conf/spark-defaults.conf" 'spark.history.retainedApplications 100' && \
   os::cmd::expect_success_and_text "${BIN} exec $worker_pod cat /opt/spark/conf/spark-defaults.conf" 'autoBroadcastJoinThreshold 20971520' && \
+  os::cmd::expect_success_and_text "${BIN} exec $worker_pod -- ls /tmp/jars | grep aws" 'com.amazonaws_aws-java-sdk-' && \
+  os::cmd::expect_success_and_text "${BIN} exec $worker_pod -- ls /tmp/jars | grep aws" 'org.apache.hadoop_hadoop-aws-' && \
   os::cmd::expect_success_and_text '${BIN} delete sparkcluster sparky-cluster' '"?sparky-cluster"? deleted'
 }
 

--- a/examples/cluster-with-config.yaml
+++ b/examples/cluster-with-config.yaml
@@ -3,6 +3,9 @@ kind: SparkCluster
 metadata:
   name: sparky-cluster                                  # compulsory
 spec:
+  mavenDependencies:                                    # optional: array of Maven resources identified by GAVs (groupId:artifactId:version)
+  - com.amazonaws:aws-java-sdk-pom:1.10.34
+  - org.apache.hadoop:hadoop-aws:2.7.3
   worker:
     instances: "2"                                      # optional defaults to 1
     memory: "1Gi"                                       # optional no defaults
@@ -23,7 +26,7 @@ spec:
                                                       # kubectl create configmap my-config --from-file=example/config.conf
   sparkConfiguration:                                 # optional, it overrides the config defined above
   - name: spark.executor.memory
-    value: 0.5g
+    value: 500m
   - name: spark.sql.conf.autoBroadcastJoinThreshold
     value: 20971520
   downloadData:                                       # optional, it downloads these files to each node

--- a/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
+++ b/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
@@ -244,6 +244,7 @@ public class InitContainersHelper {
      *  <li>if there is anything to download</li>
      *  <li>if config map with overrides exists</li>
      *  <li>if key-value config entries were passed in the custom resource/CM</li>
+     *  <li>if there are additional maven dependencies that should be downloaded</li>
      *  <li>cpu limit</li>
      * </ul>
      *
@@ -281,6 +282,8 @@ public class InitContainersHelper {
         delay += cmExists ? 3 : 0;
         delay += !cluster.getSparkConfiguration().isEmpty() ? 3 : 0;
         delay += cluster.getDownloadData().size() * 4;
+        delay += cluster.getMavenDependencies().isEmpty() ? 0 : 30;
+        delay += cluster.getMavenDependencies().size() * 4;
         return delay;
     }
 

--- a/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
+++ b/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
@@ -258,11 +258,16 @@ public class InitContainersHelper {
     public static int getExpectedDelay(SparkCluster cluster, boolean cmExists, boolean isMaster) {
         // todo: honor the chmod init cont.
         int delay = 6;
+        delay += cmExists ? 3 : 0;
+        delay += !cluster.getSparkConfiguration().isEmpty() ? 3 : 0;
+        delay += cluster.getDownloadData().size() * 4;
+        delay += cluster.getMavenDependencies().isEmpty() ? 0 : 42;
+        delay += cluster.getMavenDependencies().size() * 5;
         if (isMaster) {
             if (null != cluster.getMaster() && null != cluster.getMaster().getCpu()) {
                 try {
                     double cpu = Double.parseDouble(cluster.getMaster().getCpu());
-                    delay += (1.0 / cpu) * 3.5;
+                    delay *= Math.max(.75 / cpu, .95);
                 } catch (NumberFormatException nfe) {
                     // ignore
                 }
@@ -272,18 +277,13 @@ public class InitContainersHelper {
             if (null != cluster.getWorker() && null != cluster.getWorker().getCpu()) {
                 try {
                     double cpu = Double.parseDouble(cluster.getWorker().getCpu());
-                    delay += (1.0 / cpu) * 3.5;
+                    delay *= Math.max(.75 / cpu, .95);
                 } catch (NumberFormatException nfe) {
                     // ignore
                 }
             }
-            delay += 4;
+            delay += 5;
         }
-        delay += cmExists ? 3 : 0;
-        delay += !cluster.getSparkConfiguration().isEmpty() ? 3 : 0;
-        delay += cluster.getDownloadData().size() * 4;
-        delay += cluster.getMavenDependencies().isEmpty() ? 0 : 30;
-        delay += cluster.getMavenDependencies().size() * 4;
         return delay;
     }
 

--- a/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
+++ b/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
@@ -266,7 +266,7 @@ public class KubernetesSparkClusterDeployer {
             command.add("/bin/sh");
             command.add("-c");
             String dependencies = String.join(",", cluster.getMavenDependencies());
-            commandArgs.add("spark-submit --packages " + dependencies +" --conf spark.jars.ivy=/tmp --class no-op 0 || true; /entrypoint /launch.sh");
+            commandArgs.add("spark-submit --packages " + dependencies +" --conf spark.jars.ivy=/tmp --class no-op 0 > /tmp/spark-submit.log || true; /entrypoint /launch.sh");
         }
 
         List<String> command = isMaster ? m.getCommand() : w.getCommand();

--- a/src/main/resources/schema/sparkCluster.json
+++ b/src/main/resources/schema/sparkCluster.json
@@ -74,6 +74,12 @@
         }
       }
     },
+    "mavenDependencies": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "customImage": {
       "type": "string"
     },

--- a/src/main/resources/schema/sparkCluster.json
+++ b/src/main/resources/schema/sparkCluster.json
@@ -80,6 +80,12 @@
         "type": "string"
       }
     },
+    "mavenRepositories": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "customImage": {
       "type": "string"
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Description
before it runs the actual master/worker, it runs dummy/noop `spark-submit` command with `--packages` argument so that it can download the jars into `/tmp`. These are then reused when starting the nodes.

#### Related Issue
#213 

#### Types of changes
<!-- Use ONLY ONE that applies (and delete the rest) -->

 :sparkles: New feature (non-breaking change which adds functionality)
