### PR TITLE
[wip] Stateful sets

### DIFF
--- a/helm/spark-operator/templates/operator.yaml
+++ b/helm/spark-operator/templates/operator.yaml
@@ -31,7 +31,7 @@ metadata:
   {{- end }}
 rules:
 - apiGroups: [""]
-  resources: ["pods", "replicationcontrollers", "services", "configmaps"]
+  resources: ["pods", "replicationcontrollers", "statefulsets" , "services", "configmaps"]
   verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/manifest/olm/crd/sparkclusteroperator.1.0.1.clusterserviceversion.yaml
+++ b/manifest/olm/crd/sparkclusteroperator.1.0.1.clusterserviceversion.yaml
@@ -91,7 +91,7 @@ spec:
           verbs:
           - "*"
         - apiGroups: [""]
-          resources: ["pods", "replicationcontrollers", "services", "configmaps"]
+          resources: ["pods", "replicationcontrollers", "statefulsets" , "services", "configmaps"]
           verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch", "patch"]
         - apiGroups:
           - apiextensions.k8s.io

--- a/manifest/operator-cm.yaml
+++ b/manifest/operator-cm.yaml
@@ -9,7 +9,7 @@ metadata:
   name: edit-resources
 rules:
 - apiGroups: [""]
-  resources: ["pods", "replicationcontrollers", "services", "configmaps"]
+  resources: ["pods", "replicationcontrollers", "statefulsets", "services", "configmaps"]
   verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/manifest/operator.yaml
+++ b/manifest/operator.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: spark-operator
       containers:
       - name: spark-operator
-        image: quay.io/radanalyticsio/spark-operator:latest-released
+        image: jkremser/spark-operator:s-sets
         env:
         - name: WATCH_NAMESPACE # if not specified all the namespaces will be watched; ~ denotes the same ns as the operator's
           value: "~"
@@ -60,5 +60,5 @@ spec:
           limits:
             memory: "512Mi"
             cpu: "1000m"
-        imagePullPolicy: Never
+        imagePullPolicy: Always
 

--- a/src/main/java/io/radanalytics/operator/app/AppOperator.java
+++ b/src/main/java/io/radanalytics/operator/app/AppOperator.java
@@ -38,6 +38,7 @@ public class AppOperator extends AbstractOperator<SparkApplication> {
         String name = app.getName();
         client.services().inNamespace(namespace).withLabels(deployer.getLabelsForDeletion(name)).delete();
         client.replicationControllers().inNamespace(namespace).withLabels(deployer.getLabelsForDeletion(name)).delete();
+        client.apps().statefulSets().inNamespace(namespace).withLabels(deployer.getLabelsForDeletion(name)).delete();
         client.pods().inNamespace(namespace).withLabels(deployer.getLabelsForDeletion(name)).delete();
     }
 }

--- a/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
+++ b/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
@@ -1,6 +1,7 @@
 package io.radanalytics.operator.cluster;
 
 import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.radanalytics.operator.historyServer.HistoryServerHelper;
 import io.radanalytics.types.*;
 
@@ -34,16 +35,16 @@ public class InitContainersHelper {
      * </ol>
      *
      *
-     * @param rc ReplicationController instance
+     * @param ss StatefulSet instance
      * @param cluster SparkCluster instance
      * @param cmExists whether config map with overrides exists
-     * @return modified ReplicationController instance
+     * @return modified StatefulSet instance
      */
-    public static final ReplicationController addInitContainers(ReplicationController rc,
-                                                                 SparkCluster cluster,
-                                                                 boolean cmExists,
-                                                                 boolean isMaster) {
-        PodSpec podSpec = rc.getSpec().getTemplate().getSpec();
+    public static final StatefulSet addInitContainers(StatefulSet ss,
+                                                                SparkCluster cluster,
+                                                                boolean cmExists,
+                                                                boolean isMaster) {
+        PodSpec podSpec = ss.getSpec().getTemplate().getSpec();
 
         if (isMaster && HistoryServerHelper.needsVolume(cluster)) {
             createChmodHistoryServerContainer(cluster, podSpec);
@@ -57,8 +58,8 @@ public class InitContainersHelper {
             createConfigOverrideContainer(cluster, podSpec, cmExists);
         }
 
-        rc.getSpec().getTemplate().setSpec(podSpec);
-        return rc;
+        ss.getSpec().getTemplate().setSpec(podSpec);
+        return ss;
     }
 
     private static Container createDownloader(SparkCluster cluster, PodSpec podSpec) {

--- a/src/main/resources/schema/sparkCluster.json
+++ b/src/main/resources/schema/sparkCluster.json
@@ -38,6 +38,25 @@
           "items": {
             "type": "string"
           }
+        },
+        "persistentVolumes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mountPath": {
+                "type": "string"
+              },
+              "size": {
+                "type": "string",
+                "default": "0.3Gi"
+              },
+              "matchLabels": {
+                "type": "object",
+                "existingJavaType": "java.util.Map<String,String>"
+              }
+            }
+          }
         }
       }
     },
@@ -70,6 +89,26 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "persistentVolumes": {
+          "type": "array",
+          "items": {
+            "existingJavaType": "io.radanalytics.types.PersistentVolume",
+            "type": "object",
+            "properties": {
+              "mountPath": {
+                "type": "string"
+              },
+              "size": {
+                "type": "string",
+                "default": "0.3Gi"
+              },
+              "matchLabels": {
+                "type": "object",
+                "existingJavaType": "java.util.Map<String,String>"
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Changing what operator actually deploys. Replication controllers are considered as a low-lvl detail k8s resources and don't allow for durable data (one can't assign the persistent volume to a certain replica managed by RC).

This changes replication controllers to stateful sets, it's `wip`, because the `volumeClaimTemplates` are still not there.

  
### Description

after applying the `example/cluster.yaml`:

```
λ oc get rc
No resources found.

λ oc get statefulsets
NAME                 READY   AGE
my-spark-cluster-m   1/1     3m6s
my-spark-cluster-w   2/2     3m6s

```
 :sparkles: New feature (non-breaking change which adds functionality)
