### PR TITLE
Add route & pvc permissions for operator-cm deployments

### DIFF
--- a/helm/spark-operator/templates/operator.yaml
+++ b/helm/spark-operator/templates/operator.yaml
@@ -33,6 +33,12 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "replicationcontrollers", "services", "configmaps"]
   verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch", "patch"]
+- apiGroups: ["", "route.openshift.io"]
+  resources: ["routes"]
+  verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding

--- a/manifest/operator-cm.yaml
+++ b/manifest/operator-cm.yaml
@@ -11,6 +11,12 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "replicationcontrollers", "services", "configmaps"]
   verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch", "patch"]
+- apiGroups: ["", "route.openshift.io"]
+  resources: ["routes"]
+  verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
  
### Description
Spark operator deployments that use ConfigMaps instead of CRDs was throwing errors in the pod logs because it couldn't create a route for spark-operator-metrics --OR-- list pvcs.  This update will add CRUD for routes and get/list/watch for PVCs

#### Related Issue
N/A


#### Types of changes
:bug: Bug fix (non-breaking change which fixes an issue)
 