### PR TITLE
[minor] changing the apiVersion for Deployment from apps/v1beta1 to apps/v1

### DIFF
--- a/manifest/operator.yaml
+++ b/manifest/operator.yaml
@@ -17,7 +17,7 @@ subjects:
     name: spark-operator
     namespace: default
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: spark-operator


### PR DESCRIPTION
New versions of k8s don't work w/ v1beta1

<!-- Provide a general summary of your changes in the Title above -->
  
### Description
To avoid this error (on minikube@1.5.2 w/ k8s@1.16.2):
```
error: unable to recognize "manifest/operator.yaml": no matches for kind "Deployment" in version "apps/v1beta1"
```

 :bug: Bug fix (non-breaking change which fixes an issue)

/cc @elmiko 