### PR TITLE
Add status subblock updatest to supported CRs

### DIFF
--- a/manifest/olm/crd/sparkcluster.crd.yaml
+++ b/manifest/olm/crd/sparkcluster.crd.yaml
@@ -19,3 +19,5 @@ spec:
   - name: Age
     type: date
     JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <abstract-operator.version>0.6.14</abstract-operator.version>
+        <abstract-operator.version>0.6.15</abstract-operator.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/io/radanalytics/operator/app/AppOperator.java
+++ b/src/main/java/io/radanalytics/operator/app/AppOperator.java
@@ -31,11 +31,13 @@ public class AppOperator extends AbstractOperator<SparkApplication> {
     protected void onAdd(SparkApplication app) {
         KubernetesResourceList list = deployer.getResourceList(app, namespace);
         client.resourceList(list).inNamespace(namespace).createOrReplace();
+        setCRStatus("ready", app.getNamespace(), app.getName() );
     }
 
     @Override
     protected void onDelete(SparkApplication app) {
         String name = app.getName();
+        setCRStatus("deleted", app.getNamespace(), name );
         client.services().inNamespace(namespace).withLabels(deployer.getLabelsForDeletion(name)).delete();
         client.replicationControllers().inNamespace(namespace).withLabels(deployer.getLabelsForDeletion(name)).delete();
         client.pods().inNamespace(namespace).withLabels(deployer.getLabelsForDeletion(name)).delete();

--- a/src/main/java/io/radanalytics/operator/historyServer/HistoryServerOperator.java
+++ b/src/main/java/io/radanalytics/operator/historyServer/HistoryServerOperator.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 import java.util.WeakHashMap;
@@ -46,12 +47,14 @@ public class HistoryServerOperator extends AbstractOperator<SparkHistoryServer> 
         }
         client.resourceList(list).inNamespace(namespace).createOrReplace();
         cache.put(hs.getName(), list);
+        setCRStatus("ready", hs.getNamespace(), hs.getName());
     }
 
     @Override
     protected void onDelete(SparkHistoryServer hs) {
         log.info("Spark history server removed");
         String name = hs.getName();
+        setCRStatus("deleted", hs.getNamespace(), name);
         KubernetesResourceList list = Optional.ofNullable(cache.get(name)).orElse(deployer.getResourceList(hs, namespace, isOpenshift));
         client.resourceList(list).inNamespace(namespace).delete();
         cache.remove(name);


### PR DESCRIPTION
### Description

This adds basic status updates to the CRs managed by the spark operator. Status includes a state string and a lastTransitionTime field.  This PR is dependent on a change to the AbstractOperator in https://github.com/jvm-operators/abstract-operator/pull/62

As an initial pass, the status block available is fixed (string, date) and the changes should not break any existing subclasses of AbstractOperator class. In the future we can figure out how to add more general status.

#### Related Issue

The following issue is partly related. This is a first step toward general status, but it is mostly to satisfy failing CI in the community-operators repo because of the lack of a status block.

https://github.com/radanalyticsio/spark-operator/issues/216

#### Types of changes
 :sparkles: New feature (non-breaking change which adds functionality)