### PR TITLE
Add new request and limit values to SparkCluster CR for cpu and memory

### DIFF
--- a/.travis/.travis.test-oc-and-k8s.sh
+++ b/.travis/.travis.test-oc-and-k8s.sh
@@ -21,6 +21,16 @@ run_custom_test() {
     testCustomCluster5 || errorLogs
 }
 
+run_limit_request_tests() {
+    testNoLimits || errorLogs
+    testCpuMem || errorLogs
+    testJustLimits || errorLogs
+    testJustRequests || errorLogs
+    testRequestsAndLimits || errorLogs
+    testOverwriteRequests || errorLogs
+    testOverwriteLimits || errorLogs
+}
+
 run_tests() {
   testCreateCluster1 || errorLogs
   testScaleCluster || errorLogs
@@ -37,6 +47,9 @@ run_tests() {
   sleep 5
 
   run_custom_test || errorLogs
+  sleep 5
+  
+  run_limit_request_tests || errorLogs
 
   sleep 10
   testApp || appErrorLogs

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ spec:
 EOF
 ```
 
+# Limits and requests for cpu and memory in SparkCluster pods
+
+The operator supports multiple fields for setting limit and request values for master and worker pods.
+You can see these being used in the *examples/test* directory.
+
+* *cpu* and *memory* specify both limit _and_ request values for cpu and memory (that is, limits and requests will be equal)
+  This was the first mechanism provided for setting limits and requests and has been retained for backward compatibility.
+  However, a need was found to be able to set the requests and limits individually.
+
+* *cpuRequest* and *memoryRequest* set request values and take precedence over values from *cpu* and *memory* respectively
+
+* *cpuLimit* and *memoryLimit* set limit values and take precedence over values taken from *cpu* and *memory* respectively
+
+
 ## Spark Applications
 
 Apart from managing clusters with Apache Spark, this operator can also manage Spark applications similarly as the `GoogleCloudPlatform/spark-on-k8s-operator`. These applications spawn their own Spark cluster for their needs and it uses the Kubernetes as the native scheduling mechanism for Spark. For more details, consult the [Spark docs](https://spark.apache.org/docs/latest/running-on-kubernetes.html).

--- a/examples/test/cluster-cpumem.yaml
+++ b/examples/test/cluster-cpumem.yaml
@@ -1,0 +1,11 @@
+apiVersion: radanalytics.io/v1
+kind: SparkCluster
+metadata:
+  name: my-spark-cluster-cpumem
+spec:
+  worker:
+    instances: "1"
+    cpu: 100m
+    memory: 200m
+  master:
+    instances: "1"

--- a/examples/test/cluster-limits.yaml
+++ b/examples/test/cluster-limits.yaml
@@ -1,0 +1,11 @@
+apiVersion: radanalytics.io/v1
+kind: SparkCluster
+metadata:
+  name: my-spark-cluster-limits
+spec:
+  worker:
+    instances: "1"
+    cpuLimit: 100m
+    memoryLimit: 200m
+  master:
+    instances: "1"

--- a/examples/test/cluster-limreq.yaml
+++ b/examples/test/cluster-limreq.yaml
@@ -1,0 +1,13 @@
+apiVersion: radanalytics.io/v1
+kind: SparkCluster
+metadata:
+  name: my-spark-cluster-limreq
+spec:
+  worker:
+    instances: "1"
+    cpuLimit: 125m
+    memoryLimit: 225m
+    cpuRequest: 100m
+    memoryRequest: 200m
+  master:
+    instances: "1"

--- a/examples/test/cluster-overwritelim.yaml
+++ b/examples/test/cluster-overwritelim.yaml
@@ -1,0 +1,13 @@
+apiVersion: radanalytics.io/v1
+kind: SparkCluster
+metadata:
+  name: my-spark-cluster-overwritelim
+spec:
+  worker:
+    instances: "1"
+    cpu: 150m
+    memory: 250m
+    cpuLimit: 175m
+    memoryLimit: 275m
+  master:
+    instances: "1"

--- a/examples/test/cluster-overwritereq.yaml
+++ b/examples/test/cluster-overwritereq.yaml
@@ -1,0 +1,13 @@
+apiVersion: radanalytics.io/v1
+kind: SparkCluster
+metadata:
+  name: my-spark-cluster-overwritereq
+spec:
+  worker:
+    instances: "1"
+    cpu: 150m
+    memory: 250m
+    cpuRequest: 100m
+    memoryRequest: 200m
+  master:
+    instances: "1"

--- a/examples/test/cluster-requests.yaml
+++ b/examples/test/cluster-requests.yaml
@@ -1,0 +1,11 @@
+apiVersion: radanalytics.io/v1
+kind: SparkCluster
+metadata:
+  name: my-spark-cluster-requests
+spec:
+  worker:
+    instances: "1"
+    cpuRequest: 150m
+    memoryRequest: 250m
+  master:
+    instances: "1"

--- a/examples/test/cm/cluster-cpumem.yaml
+++ b/examples/test/cm/cluster-cpumem.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-spark-cluster-cpumem
+  labels:
+    radanalytics.io/kind: SparkCluster
+data:
+  config: |-
+    worker:
+      instances: "1"
+      cpu: 100m
+      memory: 200m

--- a/examples/test/cm/cluster-limits.yaml
+++ b/examples/test/cm/cluster-limits.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-spark-cluster-limits
+  labels:
+    radanalytics.io/kind: SparkCluster
+data:
+  config: |-
+    worker:
+      instances: "1"
+      cpuLimit: 100m
+      memoryLimit: 200m

--- a/examples/test/cm/cluster-limreq.yaml
+++ b/examples/test/cm/cluster-limreq.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-spark-cluster-limreq
+  labels:
+    radanalytics.io/kind: SparkCluster
+data:
+  config: |-
+    worker:
+      instances: "1"
+      cpuLimit: 125m
+      memoryLimit: 225m
+      cpuRequest: 100m
+      memoryRequest: 200m

--- a/examples/test/cm/cluster-overwritelim.yaml
+++ b/examples/test/cm/cluster-overwritelim.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-spark-cluster-overwritelim
+  labels:
+    radanalytics.io/kind: SparkCluster
+data:
+  config: |-
+    worker:
+      instances: "1"
+      cpu: 150m
+      memory: 250m
+      cpuLimit: 175m
+      memoryLimit: 275m

--- a/examples/test/cm/cluster-overwritereq.yaml
+++ b/examples/test/cm/cluster-overwritereq.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-spark-cluster-overwritereq
+  labels:
+    radanalytics.io/kind: SparkCluster
+data:
+  config: |-
+    worker:
+      instances: "1"
+      cpu: 150m
+      memory: 250m
+      cpuRequest: 100m
+      memoryRequest: 200m

--- a/examples/test/cm/cluster-requests.yaml
+++ b/examples/test/cm/cluster-requests.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-spark-cluster-requests
+  labels:
+    radanalytics.io/kind: SparkCluster
+data:
+  config: |-
+    worker:
+      instances: "1"
+      cpuRequest: 150m
+      memoryRequest: 250m
+

--- a/src/main/resources/schema/sparkCluster.json
+++ b/src/main/resources/schema/sparkCluster.json
@@ -19,7 +19,19 @@
         "memory": {
           "type": "string"
         },
+        "memoryRequest": {
+          "type": "string"
+        },
+        "memoryLimit": {
+          "type": "string"
+        },
         "cpu": {
+          "type": "string"
+        },
+        "cpuRequest": {
+          "type": "string"
+        },
+        "cpuLimit": {
           "type": "string"
         },
         "labels": {
@@ -52,9 +64,21 @@
         "memory": {
           "type": "string"
         },
+        "memoryRequest": {
+          "type": "string"
+        },
+        "memoryLimit": {
+          "type": "string"
+        },
         "cpu": {
           "type": "string"
         },
+        "cpuRequest": {
+          "type": "string"
+        },
+        "cpuLimit": {
+          "type": "string"
+        },        
         "labels": {
           "existingJavaType": "java.util.Map<String,String>",
           "type": "string",


### PR DESCRIPTION
### Description
Previously a SparkCluster allowed an optional value for cpu
and memory that was used to set both the limit and request
value for each. This change adds new optional fields to
individually set request and limit values.
    
To preserve backward compatibility:
* if just "cpu" or "memory" are set, the behavior is unchanged
* "cpuRequest" and "memoryRequest" will take precedence over
   values from "cpu" or "memory" for setting request values
* "cpuLimit" and "memoryLimit" will take precedence over
   values from "cpu" or "memory" for setting limit values

#### Related Issue

#### Types of changes

 :sparkles: New feature (non-breaking change which adds functionality)
