### PR TITLE
Ignore onModify if only the status block has changed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.radanalytics</groupId>
     <artifactId>spark-operator</artifactId>
-    <version>1.0.5-SNAPSHOT</version>
+    <version>1.0.5</version>
 
     <scm>
         <url>https://github.com/radanalyticsio/spark-operator</url>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.radanalytics</groupId>
     <artifactId>spark-operator</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6-SNAPSHOT</version>
 
     <scm>
         <url>https://github.com/radanalyticsio/spark-operator</url>

--- a/src/main/java/io/radanalytics/operator/app/AppOperator.java
+++ b/src/main/java/io/radanalytics/operator/app/AppOperator.java
@@ -7,6 +7,8 @@ import io.radanalytics.types.SparkApplication;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
+import java.util.HashMap;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -17,9 +19,24 @@ public class AppOperator extends AbstractOperator<SparkApplication> {
     @Inject
     private Logger log;
     private KubernetesAppDeployer deployer;
+    private Map<String, SparkApplication> apps;
 
     public AppOperator(){
+        this.apps = new HashMap<>();
+    }
 
+    private void put(SparkApplication app) {
+        apps.put(app.getName(), app);
+    }
+
+    private void delete(String name) {
+        if (apps.containsKey(name)) {
+            apps.remove(name);
+        }
+    }
+
+    private SparkApplication getApp(String name) {
+        return this.apps.get(name);
     }
 
     private void updateStatus(SparkApplication app, String state) {
@@ -44,12 +61,28 @@ public class AppOperator extends AbstractOperator<SparkApplication> {
         KubernetesResourceList list = deployer.getResourceList(app, namespace);
         client.resourceList(list).inNamespace(namespace).createOrReplace();
         updateStatus(app, "ready" );
+        put(app);
+    }
+
+    @Override
+    protected void onModify(SparkApplication newApp) {
+
+        // This comparison works to rule out a change in status because
+        // we added the status block in the AbstractOperator universally,
+        // ie it is not actually included in the SparkApplication type
+        // definition generated from json. If that ever changes, then
+        // this comparison will have to be a little smarter.
+        SparkApplication existingApp = getApp(newApp.getName());
+        if (null == existingApp || !newApp.equals(existingApp)) {
+            super.onModify(newApp);
+        }
     }
 
     @Override
     protected void onDelete(SparkApplication app) {
         String name = app.getName();
         updateStatus(app, "deleted");
+        delete(name);
         client.services().inNamespace(namespace).withLabels(deployer.getLabelsForDeletion(name)).delete();
         client.replicationControllers().inNamespace(namespace).withLabels(deployer.getLabelsForDeletion(name)).delete();
         client.pods().inNamespace(namespace).withLabels(deployer.getLabelsForDeletion(name)).delete();

--- a/src/main/java/io/radanalytics/operator/cluster/SparkClusterOperator.java
+++ b/src/main/java/io/radanalytics/operator/cluster/SparkClusterOperator.java
@@ -102,7 +102,7 @@ public class SparkClusterOperator extends AbstractOperator<SparkCluster> {
         SparkCluster existingCluster = getClusters().getCluster(name);
         if (null == existingCluster) {
             log.error("something went wrong, unable to scale existing cluster. Perhaps it wasn't deployed properly.");
-	    updateStatus(newCluster, "error, unable to scale existing cluster");
+            updateStatus(newCluster, "error, unable to scale existing cluster");
             return;
         }
 


### PR DESCRIPTION
### Description
 add overloads in SparkApplication and SparkHistoryServer for
 onModify and test whether the object has actually changed before
 calling the super method.

#### Types of changes
 :bug: Bug fix (non-breaking change which fixes an issue)

