### PR TITLE
Ignore onModify if only the status block has changed

### DIFF
--- a/src/main/java/io/radanalytics/operator/app/AppOperator.java
+++ b/src/main/java/io/radanalytics/operator/app/AppOperator.java
@@ -7,6 +7,8 @@ import io.radanalytics.types.SparkApplication;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
+import java.util.HashMap;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -17,9 +19,24 @@ public class AppOperator extends AbstractOperator<SparkApplication> {
     @Inject
     private Logger log;
     private KubernetesAppDeployer deployer;
+    private Map<String, SparkApplication> apps;
 
     public AppOperator(){
+        this.apps = new HashMap<>();
+    }
 
+    private void put(SparkApplication app) {
+        apps.put(app.getName(), app);
+    }
+
+    private void delete(String name) {
+        if (apps.containsKey(name)) {
+            apps.remove(name);
+        }
+    }
+
+    private SparkApplication getApp(String name) {
+        return this.apps.get(name);
     }
 
     private void updateStatus(SparkApplication app, String state) {
@@ -44,12 +61,28 @@ public class AppOperator extends AbstractOperator<SparkApplication> {
         KubernetesResourceList list = deployer.getResourceList(app, namespace);
         client.resourceList(list).inNamespace(namespace).createOrReplace();
         updateStatus(app, "ready" );
+        put(app);
+    }
+
+    @Override
+    protected void onModify(SparkApplication newApp) {
+
+        // TODO This comparison works to rule out a change in status because
+        // we added the status block in the AbstractOperator universally,
+        // ie it is not actually included in the SparkApplication type
+        // definition generated from json. If that ever changes, then
+        // this comparison will have to be a little smarter.
+        SparkApplication existingApp = getApp(newApp.getName());
+        if (null == existingApp || !newApp.equals(existingApp)) {
+            super.onModify(newApp);
+        }
     }
 
     @Override
     protected void onDelete(SparkApplication app) {
         String name = app.getName();
         updateStatus(app, "deleted");
+        delete(name);
         client.services().inNamespace(namespace).withLabels(deployer.getLabelsForDeletion(name)).delete();
         client.replicationControllers().inNamespace(namespace).withLabels(deployer.getLabelsForDeletion(name)).delete();
         client.pods().inNamespace(namespace).withLabels(deployer.getLabelsForDeletion(name)).delete();

--- a/src/main/java/io/radanalytics/operator/cluster/SparkClusterOperator.java
+++ b/src/main/java/io/radanalytics/operator/cluster/SparkClusterOperator.java
@@ -102,7 +102,7 @@ public class SparkClusterOperator extends AbstractOperator<SparkCluster> {
         SparkCluster existingCluster = getClusters().getCluster(name);
         if (null == existingCluster) {
             log.error("something went wrong, unable to scale existing cluster. Perhaps it wasn't deployed properly.");
-	    updateStatus(newCluster, "error, unable to scale existing cluster");
+            updateStatus(newCluster, "error, unable to scale existing cluster");
             return;
         }
 

--- a/src/main/java/io/radanalytics/operator/historyServer/HistoryServerOperator.java
+++ b/src/main/java/io/radanalytics/operator/historyServer/HistoryServerOperator.java
@@ -13,6 +13,7 @@ import javax.inject.Singleton;
 
 import java.lang.Thread;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Optional;
 import java.util.WeakHashMap;
 
@@ -25,9 +26,24 @@ public class HistoryServerOperator extends AbstractOperator<SparkHistoryServer> 
     private KubernetesHistoryServerDeployer deployer;
     private boolean osClient = false;
     private Map<String, KubernetesResourceList> cache = new WeakHashMap<>();
+    private Map<String, SparkHistoryServer> hss;
 
     public HistoryServerOperator() {
+        this.hss = new HashMap<>();
+    }
 
+    private void put(SparkHistoryServer hs) {
+        hss.put(hs.getName(), hs);
+    }
+
+    private void delete(String name) {
+        if (hss.containsKey(name)) {
+            hss.remove(name);
+        }
+    }
+
+    private SparkHistoryServer getHS(String name) {
+        return this.hss.get(name);
     }
 
    private void updateStatus(SparkHistoryServer hs, String state) {
@@ -62,6 +78,21 @@ public class HistoryServerOperator extends AbstractOperator<SparkHistoryServer> 
         client.resourceList(list).inNamespace(namespace).createOrReplace();
         cache.put(hs.getName(), list);
         updateStatus(hs, "ready");
+        put(hs);
+    }
+
+    @Override
+    protected void onModify(SparkHistoryServer newHs) {
+
+        // TODO This comparison works to rule out a change in status because
+        // we added the status block in the AbstractOperator universally,
+        // ie it is not actually included in the SparkHistoryServer type
+        // definition generated from json. If that ever changes, then
+        // this comparison will have to be a little smarter.
+        SparkHistoryServer existingHs = getHS(newHs.getName());
+        if (null == existingHs || !newHs.equals(existingHs)) {
+            super.onModify(newHs);
+        }
     }
 
     @Override
@@ -69,6 +100,7 @@ public class HistoryServerOperator extends AbstractOperator<SparkHistoryServer> 
         log.info("Spark history server removed");
         String name = hs.getName();
         updateStatus(hs, "deleted");
+        delete(name);
         KubernetesResourceList list = Optional.ofNullable(cache.get(name)).orElse(deployer.getResourceList(hs, namespace, isOpenshift));
         client.resourceList(list).inNamespace(namespace).delete();
         cache.remove(name);


### PR DESCRIPTION
### Description

add overloads in SparkApplication and SparkHistoryServer for
onModify and test whether the object has actually changed before
calling the super method.

#### Types of changes
 :bug: Bug fix (non-breaking change which fixes an issue)
 