### PR TITLE
Fix a bug when specifying NoSchedule node tolerations

### DIFF
--- a/examples/test/cluster-node-tolerations.yaml
+++ b/examples/test/cluster-node-tolerations.yaml
@@ -9,6 +9,10 @@ spec:
       value: foo_value
       effect: NoExecute
       tolerationSeconds: 60
+    - key: bar_key
+      operator: Equal
+      value: bar_value
+      effect: NoSchedule
   worker:
     instances: "1"
   master:

--- a/examples/test/cm/cluster-node-tolerations.yaml
+++ b/examples/test/cm/cluster-node-tolerations.yaml
@@ -12,6 +12,10 @@ data:
         value: foo_value
         effect: NoExecute
         tolerationSeconds: 60
+      - key: bar_key
+        operator: Equal
+        value: bar_value
+        effect: NoSchedule
     worker:
       instances: "1"
     master:

--- a/spark-operator/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
+++ b/spark-operator/src/main/java/io/radanalytics/operator/cluster/KubernetesSparkClusterDeployer.java
@@ -268,7 +268,13 @@ public class KubernetesSparkClusterDeployer {
         List<Toleration> tolerations = new ArrayList<Toleration>();
         List<NodeToleration> nodeTolerations = cluster.getNodeTolerations();
         nodeTolerations.forEach(t -> {
-            tolerations.add(new Toleration(t.getEffect(), t.getKey(), t.getOperator(), (long) t.getTolerationSeconds(), t.getValue()));
+            Toleration tol;
+            if (t.getTolerationSeconds() == null) {
+                tol = new Toleration(t.getEffect(), t.getKey(), t.getOperator(), null, t.getValue());
+            } else {
+                tol = new Toleration(t.getEffect(), t.getKey(), t.getOperator(), (long) t.getTolerationSeconds(), t.getValue());
+            }
+            tolerations.add(tol);
         });
         return tolerations;
 


### PR DESCRIPTION
 
### Description

I discovered a bug that prevents a user from being able to specify Node
Tolerations with the "NoSchedule" effect. These types of tolerations do
not have the "tolerationSeconds" setting, and Kubernetes complains if
you attempt to set them. My previous implementation did not properly
allow for creating a toleration when the tolerationSeconds setting was
not specified.

#### Related Issue
None


#### Types of changes
 :bug: Bug fix (non-breaking change which fixes an issue)
