### PR TITLE
Added a new optional parameter to the SparkCluster CRD to specify init container image

### DIFF
--- a/spark-operator/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
+++ b/spark-operator/src/main/java/io/radanalytics/operator/cluster/InitContainersHelper.java
@@ -83,7 +83,7 @@ public class InitContainersHelper {
 
         Container downloader = new ContainerBuilder()
                 .withName("downloader")
-                .withImage("busybox")
+                .withImage(Optional.ofNullable(cluster.getCustomInitContainerImage()).orElse("busybox"))
                 .withImagePullPolicy("IfNotPresent")
                 .withCommand("/bin/sh", "-xc")
                 .withArgs(downloaderCmd.toString())
@@ -125,7 +125,7 @@ public class InitContainersHelper {
         Container chmod = new ContainerBuilder()
                 .withName("chmod-history-server")
 //                .withNewSecurityContext().withPrivileged(true).endSecurityContext()
-                .withImage("busybox")
+                .withImage(Optional.ofNullable(cluster.getCustomInitContainerImage()).orElse("busybox"))
                 .withCommand("/bin/sh", "-xc")
                 .withArgs("mkdir -p " + sharedVolume.getMountPath() + " || true ; chmod -R go+ws " + sharedVolume.getMountPath() + " || true")
                 .withVolumeMounts(mount)
@@ -201,7 +201,7 @@ public class InitContainersHelper {
 
         Container overrideConfig = new ContainerBuilder()
                 .withName("override-config")
-                .withImage("busybox")
+                .withImage(Optional.ofNullable(cluster.getCustomInitContainerImage()).orElse("busybox"))
                 .withImagePullPolicy("IfNotPresent")
                 .withCommand("/bin/sh", "-xc")
                 .withArgs(overrideConfigCmd.toString())

--- a/spark-operator/src/main/resources/schema/sparkCluster.json
+++ b/spark-operator/src/main/resources/schema/sparkCluster.json
@@ -143,6 +143,9 @@
     "customImage": {
       "type": "string"
     },
+    "customInitContainerImage": {
+      "type": "string"
+    },
     "metrics": {
       "type": "boolean",
       "default": "false"


### PR DESCRIPTION
#### Description
Very simple change that adds in the ability to configure the init container image used and if not specified then defaults to previous behaviour.

#### Related Issue
tackles issue #326


#### Types of changes
 :sparkles: New feature (non-breaking change which adds functionality)
