### PR TITLE
Update k8s APIs from deprecated versions

### DIFF
--- a/examples/test/history-server/externalStorage/ceph-nano.yaml
+++ b/examples/test/history-server/externalStorage/ceph-nano.yaml
@@ -18,7 +18,7 @@
       app: ceph
       daemon: demo
 ---
-  apiVersion: apps/v1beta1
+  apiVersion: apps/v1
   kind: StatefulSet
   metadata:
     labels:

--- a/helm/spark-operator/templates/operator.yaml
+++ b/helm/spark-operator/templates/operator.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- end }}
 ---
 {{- if .Values.env.crd }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: spark-operator-edit-resources
@@ -23,7 +23,7 @@ subjects:
     namespace: "{{ default "default" .Values.env.installNamespace }}"
 {{- else }}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: edit-resources
   {{- if .Values.env.installNamespace }}
@@ -40,7 +40,7 @@ rules:
   resources: ["persistentvolumeclaims"]
   verbs: ["get", "list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: spark-operator-edit-resources
@@ -56,7 +56,7 @@ subjects:
     name: spark-operator
 {{- end }}
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: spark-operator
@@ -77,7 +77,7 @@ spec:
     metadata:
       labels: *default-labels
       initializers:
-        pending: []  
+        pending: []
     spec:
       serviceAccountName: spark-operator
       containers:
@@ -103,4 +103,3 @@ spec:
             memory: {{ .Values.resources.memory }}
             cpu: {{ .Values.resources.cpu }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-

--- a/manifest/olm/configmap-based-all-in-one-csv.yaml
+++ b/manifest/olm/configmap-based-all-in-one-csv.yaml
@@ -5,7 +5,7 @@ metadata:
   name: spark-operator
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: edit-spark-resources
 rules:
@@ -14,7 +14,7 @@ rules:
   verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch", "patch"]
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: spark-operator-edit-spark-resources
 subjects:

--- a/manifest/operator-cm.yaml
+++ b/manifest/operator-cm.yaml
@@ -4,7 +4,7 @@ metadata:
   name: spark-operator
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: edit-resources
 rules:
@@ -18,7 +18,7 @@ rules:
   resources: ["persistentvolumeclaims"]
   verbs: ["get", "list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: spark-operator-edit-resources
@@ -30,7 +30,7 @@ subjects:
   - kind: ServiceAccount
     name: spark-operator
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: spark-operator
@@ -76,4 +76,3 @@ spec:
             memory: "512Mi"
             cpu: "1000m"
         imagePullPolicy: IfNotPresent
-

--- a/monitoring/example-cluster-with-monitoring.yaml
+++ b/monitoring/example-cluster-with-monitoring.yaml
@@ -42,7 +42,7 @@ kind: ServiceAccount
 metadata:
   name: prometheus
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus
@@ -61,7 +61,7 @@ rules:
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus

--- a/monitoring/prometheus-operator.yaml
+++ b/monitoring/prometheus-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus-operator
@@ -11,7 +11,7 @@ subjects:
   name: prometheus-operator
   namespace: default
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus-operator


### PR DESCRIPTION
### Description

Change Deployments and StatefulSets to apps/v1
Change rbac.authorization.k8s.io to v1
https://kubernetes.io/docs/reference/using-api/deprecation-guide/

#### Types of changes

 :bug: Bug fix (non-breaking change which fixes an issue)
